### PR TITLE
Add support to provide VM details during VM deployment - when using custom offering

### DIFF
--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -165,6 +165,11 @@ func resourceCloudStackInstance() *schema.Resource {
 				},
 			},
 
+			"details": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+
 			"expunge": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -206,7 +211,13 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	// Create a new parameter struct
 	p := cs.VirtualMachine.NewDeployVirtualMachineParams(serviceofferingid, templateid, zone.Id)
 	p.SetStartvm(d.Get("start_vm").(bool))
-
+	vmDetails := make(map[string]string)
+	if details, ok := d.GetOk("details"); ok {
+		for k, v := range details.(map[string]interface{}) {
+			vmDetails[k] = v.(string)
+		}
+		p.SetDetails(vmDetails)
+	}
 	// Set the name
 	name, hasName := d.GetOk("name")
 	if hasName {


### PR DESCRIPTION
PR fixes: https://github.com/apache/cloudstack-terraform-provider/issues/4
The PR adds support to provide vm details - when using custom offering:

### Prior Fix:
```
$ terraform apply 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudstack_instance.web will be created
  + resource "cloudstack_instance" "web" {
      + display_name     = (known after apply)
      + expunge          = false
      + group            = (known after apply)
      + id               = (known after apply)
      + ip_address       = (known after apply)
      + name             = "server-1"
      + network_id       = "07b408a2-d65f-4654-be59-b964528153cd"
      + project          = (known after apply)
      + root_disk_size   = (known after apply)
      + service_offering = "custom"
      + start_vm         = true
      + tags             = (known after apply)
      + template         = "ac16f352-25a6-11ec-8071-50eb7122da94"
      + zone             = "c752ddc2-b14e-4f96-b157-c5f02cff6046"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudstack_instance.web: Creating...
╷
│ Error: Error creating the new instance server-1: CloudStack API error 431 (CSExceptionErrorCode: 4350): Need to specify custom parameter values cpu, cpu speed and memory when using custom offering
│ 
│   with cloudstack_instance.web,
│   on cs_example.tf line 11, in resource "cloudstack_instance" "web":
│   11: resource "cloudstack_instance" "web" {
│ 
╵

```

### Terraform config:

```
terraform {
  required_providers {
    cloudstack = {
       source = "cloudstack/cloudstack"
       version = "0.4.0-pre"
    }
  }
}


resource "cloudstack_instance" "web" {
  name             = "server-1"
  service_offering = "custom"
  network_id       = "c4a3303c-376d-4d56-b336-1bd91cb130b6"
  template         = "d4c2f9c6-1d18-11ec-9173-50eb7122da94"
  zone             = "d4a81f75-5d92-415e-ab59-e85cc2ce56d9"
  details = {"cpuNumber" = "2", "memory" = "500"}
}

```
### Post Fix:
did a `make build` - which generates the `terraform-provider-cloudstack` binary and referenced the locally generated binary
```
$ terraform apply 
cloudstack_ssh_keypair.default: Refreshing state... [id=myKey]
cloudstack_instance.web: Refreshing state... [id=462a422e-0dbd-4a55-87c9-16c53f912b84]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # cloudstack_ssh_keypair.default has been deleted
  - resource "cloudstack_ssh_keypair" "default" {
      - fingerprint = "31:f7:ad:fb:63:b6:85:23:5b:d4:ab:af:ce:71:53:ec" -> null
      - id          = "myKey" -> null
      - name        = "myKey" -> null
      - public_key  = <<-EOT
            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCu4YuPz1rwUoCyB1blA+s8qygIULqcWPd/PjLVqqeyWH8OVSb3mJDW/kRW5jaZhQs3qykXr7/LghU1xZjmb77uI+G2AmRLgZPcn6x2aaanBYfDzOVdwfzwy9Aol2148sZBHg8QBE0p7UikBahGmq33HYwRxwMgLKQDdPwlU4ByeRGvZTHu7cgwbrXewsh0uMkRzfXpfUG140i9hwgDT4kqwqdxipDdpNuC9SHd52qu1dbrX/z8P1RumjQdboQzWfsiAlGfwpPWXnQC+I+nd7Cv0UJ95CUuu9LN/v+P1fDdY2ktSBnPUldAAysORVDtFaAyovfDvkU5IHag+Et35W9aVZ/tQSm/Ft97oyvovgbahVaDQI9mW94RtDtkLxBgwXnheHAo07MjiIQJmHMDWuSJg11pcEvNVhn6iB7K3NI/0wCdnNnljE5ZKou2SxGkOhU7jLdCqNbr/Y98lta5OCVy2cysSbxzG2Bojzed8CMBmkMDTH5ihScebEfQeGuCrCMcVyFRScmU1yrEDdhJjcuCqvDKtyCuiduD/DAg8EXk/f31xb6FFxLs1X1idZ2w7Ykg8s4i8RkAU/5+RdglINk6TIFFshGu4VuPzNHPqMxs1PyDjQK4vXaOCAaYxOtERwtdGJ5UDKlz50hwS7cHyQqbAtvTlqA6U8d1VeAm9AXDmQ== pearl1594@gmail.com
        EOT -> null
    }
  # cloudstack_instance.web has been deleted
  - resource "cloudstack_instance" "web" {
      - details          = {
          - "cpuNumber" = "2"
          - "memory"    = "500"
        } -> null
      - display_name     = "server-1" -> null
      - expunge          = false -> null
      - id               = "462a422e-0dbd-4a55-87c9-16c53f912b84" -> null
      - ip_address       = "10.1.1.101" -> null
      - name             = "server-1" -> null
      - network_id       = "c4a3303c-376d-4d56-b336-1bd91cb130b6" -> null
      - root_disk_size   = 2 -> null
      - service_offering = "custom" -> null
      - start_vm         = true -> null
      - tags             = {} -> null
      - template         = "d4c2f9c6-1d18-11ec-9173-50eb7122da94" -> null
      - zone             = "d4a81f75-5d92-415e-ab59-e85cc2ce56d9" -> null
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudstack_instance.web will be created
  + resource "cloudstack_instance" "web" {
      + details          = {
          + "cpuNumber" = "2"
          + "memory"    = "500"
        }
      + display_name     = (known after apply)
      + expunge          = false
      + group            = (known after apply)
      + id               = (known after apply)
      + ip_address       = (known after apply)
      + name             = "server-1"
      + network_id       = "07b408a2-d65f-4654-be59-b964528153cd"
      + project          = (known after apply)
      + root_disk_size   = (known after apply)
      + service_offering = "custom"
      + start_vm         = true
      + tags             = (known after apply)
      + template         = "ac16f352-25a6-11ec-8071-50eb7122da94"
      + zone             = "c752ddc2-b14e-4f96-b157-c5f02cff6046"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudstack_instance.web: Creating...
cloudstack_instance.web: Creation complete after 4s [id=4481785c-b5e0-4806-99ad-a634e4db2f3e]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Validated using cmk / UI:
```
(localcloud) 🐱 > list virtualmachines name=server-1 filter=name,id,templateid,templatename,zoneid,zonename,serviceofferingname,serviceofferingid,
{
  "count": 1,
  "virtualmachine": [
    {
      "id": "fcd5029f-47d9-43a4-8dd8-22e0b52dccf3",
      "name": "server-1",
      "serviceofferingid": "2b8a9da1-c29c-4c6a-80d8-800af1c02af8",
      "serviceofferingname": "custom",
      "templateid": "ac16f352-25a6-11ec-8071-50eb7122da94",
      "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
      "zoneid": "c752ddc2-b14e-4f96-b157-c5f02cff6046",
      "zonename": "Sandbox-simulator"
    }
  ]
}
```
