### PR TITLE
Fix port forwarding to update state only if there are no errors

### DIFF
--- a/cloudstack/resource_cloudstack_port_forward.go
+++ b/cloudstack/resource_cloudstack_port_forward.go
@@ -109,13 +109,12 @@ func resourceCloudStackPortForwardCreate(d *schema.ResourceData, meta interface{
 		forwards := resourceCloudStackPortForward().Schema["forward"].ZeroValue().(*schema.Set)
 
 		err := createPortForwards(d, meta, forwards, nrs)
-
-		// We need to update this first to preserve the correct state
-		d.Set("forward", forwards)
-
 		if err != nil {
 			return err
 		}
+
+		// We need to update this first to preserve the correct state
+		d.Set("forward", forwards)
 	}
 
 	return resourceCloudStackPortForwardRead(d, meta)


### PR DESCRIPTION
This PR fixes the issue https://github.com/apache/cloudstack-terraform-provider/issues/21, where PF state is not updated properly in Terraform.

Verified steps:
1. Create VM and a new network
2. Acquire an IP
3. Create PF rule => successfully created
4. Make another attempt such that PF rule creation should fail
5. Retry with correct steps to get succeeded => successfully created

4 and 5 steps are the actual steps which got failed in the issue