### PR TITLE
Add instance data source

### DIFF
--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -41,10 +41,7 @@ func dataSourceCloudstackInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+
 			"display_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -87,7 +84,7 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 	for _, instance := range csInstances.VirtualMachines {
 		log.Printf("Instance ===============> %v", instance)
 		if instance.Id == instance_id {
-
+			d.SetId(instance.Id)
 			d.Set("instance_id", instance.Id)
 			d.Set("account", instance.Account)
 			d.Set("created", instance.Created)

--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -20,16 +20,95 @@
 package cloudstack
 
 import (
+	"log"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceCloudstackInstance() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceCloudstackInstanceRead,
-		Schema: map[string]*schema.Schema{},
+		Read: dataSourceCloudstackInstanceRead,
+		Schema: map[string]*schema.Schema{
+
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed values
+			"account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// "ip_address": {
+			// 	Type:     schema.TypeString,
+			// 	Computed: true,
+			// },
+		},
 	}
 }
 
 func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("Instance Data Source Read Started")
+
+	cs := meta.(*cloudstack.CloudStackClient)
+	p := cs.VirtualMachine.NewListVirtualMachinesParams()
+	instance_id := d.Get("instance_id").(string)
+
+	log.Printf("Instance ID =====================> %v", instance_id)
+
+	csInstances, _ := cs.VirtualMachine.ListVirtualMachines(p)
+
+	for _, instance := range csInstances.VirtualMachines {
+		log.Printf("Instance ===============> %v", instance)
+		if instance.Id == instance_id {
+
+			d.Set("instance_id", instance.Id)
+			d.Set("account", instance.Account)
+			d.Set("created", instance.Created)
+			d.Set("display_name", instance.Displayname)
+			d.Set("state", instance.State)
+			d.Set("host_id", instance.Hostid)
+			d.Set("zone_id", instance.Zoneid)
+
+			log.Printf("=========================================================================")
+
+			log.Printf("Instance-ID being Set To: ===============> %v", d.Get("instance_id").(string))
+			log.Printf("Instance-Created being Set To: ===============> %v", d.Get("created").(string))
+			log.Printf("Instance-Display-Name being Set To: ===============> %v", d.Get("display_name").(string))
+			log.Printf("Instance-State being Set To: ===============> %v", d.Get("state").(string))
+			log.Printf("Instance-Host-ID being Set To: ===============> %v", d.Get("host_id").(string))
+			log.Printf("Instance-Zone-ID being Set To: ===============> %v", d.Get("zone_id").(string))
+
+			log.Printf("=========================================================================")
+		}
+	}
+	log.Printf("Instance Data Source Read Ended")
+
 	return nil
 }

--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -1,0 +1,35 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCloudstackInstance() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceCloudstackInstanceRead,
+		Schema: map[string]*schema.Schema{},
+	}
+}
+
+func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -20,7 +20,12 @@
 package cloudstack
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -30,13 +35,14 @@ func dataSourceCloudstackInstance() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceCloudstackInstanceRead,
 		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
 
+			//Computed values
 			"instance_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Computed: true,
 			},
 
-			// Computed values
 			"account": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -62,10 +68,7 @@ func dataSourceCloudstackInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			// "ip_address": {
-			// 	Type:     schema.TypeString,
-			// 	Computed: true,
-			// },
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -75,37 +78,96 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	cs := meta.(*cloudstack.CloudStackClient)
 	p := cs.VirtualMachine.NewListVirtualMachinesParams()
-	instance_id := d.Get("instance_id").(string)
 
-	log.Printf("Instance ID =====================> %v", instance_id)
+	csInstances, err := cs.VirtualMachine.ListVirtualMachines(p)
+	if err != nil {
+		return fmt.Errorf("Failed to list instances: %s", err)
+	}
 
-	csInstances, _ := cs.VirtualMachine.ListVirtualMachines(p)
+	filters := d.Get("filter")
+	var instances []*cloudstack.VirtualMachine
 
-	for _, instance := range csInstances.VirtualMachines {
-		log.Printf("Instance ===============> %v", instance)
-		if instance.Id == instance_id {
-			d.SetId(instance.Id)
-			d.Set("instance_id", instance.Id)
-			d.Set("account", instance.Account)
-			d.Set("created", instance.Created)
-			d.Set("display_name", instance.Displayname)
-			d.Set("state", instance.State)
-			d.Set("host_id", instance.Hostid)
-			d.Set("zone_id", instance.Zoneid)
+	for _, i := range csInstances.VirtualMachines {
+		match, err := applyInstanceFilters(i, filters.(*schema.Set))
+		if err != nil {
+			return err
+		}
 
-			log.Printf("=========================================================================")
-
-			log.Printf("Instance-ID being Set To: ===============> %v", d.Get("instance_id").(string))
-			log.Printf("Instance-Created being Set To: ===============> %v", d.Get("created").(string))
-			log.Printf("Instance-Display-Name being Set To: ===============> %v", d.Get("display_name").(string))
-			log.Printf("Instance-State being Set To: ===============> %v", d.Get("state").(string))
-			log.Printf("Instance-Host-ID being Set To: ===============> %v", d.Get("host_id").(string))
-			log.Printf("Instance-Zone-ID being Set To: ===============> %v", d.Get("zone_id").(string))
-
-			log.Printf("=========================================================================")
+		if match {
+			instances = append(instances, i)
 		}
 	}
-	log.Printf("Instance Data Source Read Ended")
+
+	if len(instances) == 0 {
+		return fmt.Errorf("No instance is matching with the specified regex")
+	}
+
+	instance, err := latestInstance(instances)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Selected instances: %s\n", instance.Displayname)
+
+	return instanceDescriptionAttributes(d, instance)
+}
+
+func instanceDescriptionAttributes(d *schema.ResourceData, instance *cloudstack.VirtualMachine) error {
+	d.SetId(instance.Id)
+	d.Set("instance_id", instance.Id)
+	d.Set("account", instance.Account)
+	d.Set("created", instance.Created)
+	d.Set("display_name", instance.Displayname)
+	d.Set("state", instance.State)
+	d.Set("host_id", instance.Hostid)
+	d.Set("zone_id", instance.Zoneid)
+
+	tags := make(map[string]interface{})
+	for _, tag := range instance.Tags {
+		tags[tag.Key] = tag.Value
+	}
+	d.Set("tags", tags)
 
 	return nil
+}
+
+func latestInstance(instances []*cloudstack.VirtualMachine) (*cloudstack.VirtualMachine, error) {
+	var latest time.Time
+	var instance *cloudstack.VirtualMachine
+
+	for _, i := range instances {
+		created, err := time.Parse("2006-01-02T15:04:05-0700", i.Created)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse creation date of an instance: %s", err)
+		}
+
+		if created.After(latest) {
+			latest = created
+			instance = i
+		}
+	}
+
+	return instance, nil
+}
+
+func applyInstanceFilters(instance *cloudstack.VirtualMachine, filters *schema.Set) (bool, error) {
+	var instanceJSON map[string]interface{}
+	i, _ := json.Marshal(instance)
+	err := json.Unmarshal(i, &instanceJSON)
+	if err != nil {
+		return false, err
+	}
+	for _, f := range filters.List() {
+		m := f.(map[string]interface{})
+		r, err := regexp.Compile(m["value"].(string))
+		if err != nil {
+			return false, fmt.Errorf("Invalid regex: %s", err)
+		}
+		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
+		instanceField := instanceJSON[updatedName].(string)
+		if !r.MatchString(instanceField) {
+			return false, nil
+		}
+
+	}
+	return true, nil
 }

--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -108,6 +108,8 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 	nic := d.Get("nic").([]interface{})
 	var instances []*cloudstack.VirtualMachine
 
+	//the if-else block to check whether to filter the data source by an IP address
+	// or by any other exported attributes
 	if len(nic) != 0 {
 		ip_address := nic[0].(map[string]interface{})["ip_address"]
 		for _, i := range csInstances.VirtualMachines {
@@ -115,7 +117,6 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 				instances = append(instances, i)
 			}
 		}
-
 	} else {
 		for _, i := range csInstances.VirtualMachines {
 			match, err := applyInstanceFilters(i, filters.(*schema.Set))
@@ -132,7 +133,8 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 	if len(instances) == 0 {
 		return fmt.Errorf("No instance is matching with the specified regex")
 	}
-
+	//return the latest instance from the list of filtered instances according
+	//to its creation date
 	instance, err := latestInstance(instances)
 	if err != nil {
 		return err

--- a/cloudstack/data_source_cloudstack_instance_test.go
+++ b/cloudstack/data_source_cloudstack_instance_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
+//basic acceptance to check if the display_name attribute has same value in
+//the created instance and its data source respectively.
 func TestAccInstanceDataSource_basic(t *testing.T) {
 	resourceName := "cloudstack_instance.my_instance"
 	datasourceName := "data.cloudstack_instance.my_instance_test"

--- a/cloudstack/data_source_cloudstack_instance_test.go
+++ b/cloudstack/data_source_cloudstack_instance_test.go
@@ -1,0 +1,66 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceCloudStackInstance_basic(t *testing.T) {
+	var instance cloudstack.VirtualMachine
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCloudStackInstance_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCheckCloudStackInstanceExists(
+						"cloudstack_instance.foobar", &instance),
+					testAccDataSourceCheckCloudStackInstanceAttributes(&instance),
+					resource.TestCheckResourceAttr(
+						"cloudstack_instance.foobar", "user_data", "0cf3dcdc356ec8369494cb3991985ecd5296cdd5"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCloudStackInstance_basic = ``
+
+func testAccDataSourceCheckCloudStackInstanceExists(
+	n string, instance *cloudstack.VirtualMachine) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}
+
+func testAccDataSourceCheckCloudStackInstanceAttributes(
+	instance *cloudstack.VirtualMachine) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}

--- a/cloudstack/data_source_cloudstack_ssh_keypair.go
+++ b/cloudstack/data_source_cloudstack_ssh_keypair.go
@@ -1,0 +1,113 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCloudstackSSHKeyPair() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudstackSSHKeyPairRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+
+			//Computed values
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudstackSSHKeyPairRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+	p := cs.SSH.NewListSSHKeyPairsParams()
+	csSshKeyPairs, err := cs.SSH.ListSSHKeyPairs(p)
+
+	if err != nil {
+		return fmt.Errorf("Failed to list ssh key pairs: %s", err)
+	}
+	filters := d.Get("filter")
+	var sshKeyPair *cloudstack.SSHKeyPair
+
+	for _, k := range csSshKeyPairs.SSHKeyPairs {
+		match, err := applySshKeyPairsFilters(k, filters.(*schema.Set))
+		if err != nil {
+			return err
+		}
+		if match {
+			sshKeyPair = k
+		}
+	}
+
+	if sshKeyPair == nil {
+		return fmt.Errorf("No ssh key pair is matching with the specified regex")
+	}
+	log.Printf("[DEBUG] Selected ssh key pair: %s\n", sshKeyPair.Name)
+
+	return sshKeyPairDescriptionAttributes(d, sshKeyPair)
+}
+
+func sshKeyPairDescriptionAttributes(d *schema.ResourceData, sshKeyPair *cloudstack.SSHKeyPair) error {
+	d.SetId(sshKeyPair.Name)
+	d.Set("fingerprint", sshKeyPair.Fingerprint)
+	d.Set("name", sshKeyPair.Name)
+
+	return nil
+}
+
+func applySshKeyPairsFilters(sshKeyPair *cloudstack.SSHKeyPair, filters *schema.Set) (bool, error) {
+	var sshKeyPairJSON map[string]interface{}
+	k, _ := json.Marshal(sshKeyPair)
+	err := json.Unmarshal(k, &sshKeyPairJSON)
+	if err != nil {
+		return false, err
+	}
+
+	for _, f := range filters.List() {
+		m := f.(map[string]interface{})
+		r, err := regexp.Compile(m["value"].(string))
+		if err != nil {
+			return false, fmt.Errorf("Invalid regex: %s", err)
+		}
+		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
+		sshKeyPairField := sshKeyPairJSON[updatedName].(string)
+		if !r.MatchString(sshKeyPairField) {
+			return false, nil
+		}
+
+	}
+	return true, nil
+}

--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -78,7 +78,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"cloudstack_template": dataSourceCloudstackTemplate(),
+			"cloudstack_template":    dataSourceCloudstackTemplate(),
+			"cloudstack_ssh_keypair": dataSourceCloudstackSSHKeyPair(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -80,6 +80,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudstack_template":    dataSourceCloudstackTemplate(),
 			"cloudstack_ssh_keypair": dataSourceCloudstackSSHKeyPair(),
+			"cloudstack_instance":    dataSourceCloudstackInstance(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Hello @Pearl1594 and @harikrishna-patnala. I'm opening this up as a draft PR to get some feedback. 

I'm implementing a very basic data source to read Virtual Machine (Instance) resource, using the `instance_id` as an input in the terraform configuration file. Once I have this working successfully, I'll write different filters to extend its functionality and also remove all `log.Printf()` calls to make the code cleaner. 

So, at the moment, I am able to associate resource data with `*schema.ResourceData`. This has been confirmed by running the `DEBUG` trace on the Terraform configuration file (main.tf) but when I try to read instance data using Terraform, the output block always returns `null`. I am trying to figure out why is that the case. Could you also pleas etake a look and suggest something? 

I am attaching the main.tf and the logs I have captured. 

From `main.tf`:

```
data "cloudstack_instance" "my_instance" {
  instance_id="153aa39d-5f61-4cf8-8e17-687ee25807ff"


}

output "instance-output" {
  value = "${data.cloudstack_instance.my_instance}"
}

```

`terraform apply` output:

```
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - cloudstack/cloudstack in /home/darora/.terraform.d/plugins/cloudstack-dev/bin
│  - edu/hashicups in /home/darora/.terraform.d/plugins/hashicorp.com/edu/hashicups/0.3.1/amd64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible
│ with published releases.
╵
data.cloudstack_instance.my_instance: Reading...
cloudstack_instance.instance-test-a: Refreshing state... [id=153aa39d-5f61-4cf8-8e17-687ee25807ff]
cloudstack_instance.instance-test-c: Refreshing state... [id=9e68b9b1-5434-4cce-bfcf-d7d42b86adc8]
cloudstack_instance.instance-test-b: Refreshing state... [id=ed55a876-f434-4aa1-840e-2e40249bf199]
data.cloudstack_instance.my_instance: Read complete after 0s

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

instance-output = {
  "account" = tostring(null)
  "created" = tostring(null)
  "display_name" = tostring(null)
  "host_id" = tostring(null)
  "id" = tostring(null)
  "instance_id" = tostring(null)
  "name" = tostring(null)
  "state" = tostring(null)
  "zone_id" = tostring(null)
}

```


[Terraform_Refresh.log](https://github.com/apache/cloudstack-terraform-provider/files/8819723/Terraform_Refresh.log)

Issue: https://github.com/apache/cloudstack/issues/6016