### PR TITLE
fix for using display_text as a filter in template datasource

### DIFF
--- a/cloudstack/data_source_cloudstack_template.go
+++ b/cloudstack/data_source_cloudstack_template.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
@@ -180,8 +181,8 @@ func applyFilters(template *cloudstack.Template, filters *schema.Set) (bool, err
 		if err != nil {
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
-
-		templateField := templateJSON[m["name"].(string)].(string)
+		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
+		templateField := templateJSON[updatedName].(string)
 		if !r.MatchString(templateField) {
 			return false, nil
 		}


### PR DESCRIPTION
This PR fixes an issue with template datasource where provider crashes when using `display_text` as a filter, i.e. issue# https://github.com/apache/cloudstack-terraform-provider/issues/42