### PR TITLE
Adding documentation for new data sources added to cloudstack-terraform-proivder

### DIFF
--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "cloudstack"
+page_title: "Cloudstack: cloudstack_instance"
+sidebar_current: "docs-cloudstack-datasource-instance"
+description: |-
+  Get informations on a cloudstack instance.
+---
+
+# cloudstack_instance
+
+Use this datasource to get the ID of an instance for use in other resources.
+
+### Example Usage
+
+```hcl
+data "cloudstack_instance" "my_instance" {
+  filter {
+    name = "name" 
+    value = "server-a"
+  }
+  
+  nic {
+    ip_address="10.1.1.37"
+  }  
+```
+
+### Argument Reference
+
+* `filter` - (Required) One or more name/value pairs to filter off of. You can apply filters on any exported attributes.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `instance_id` - The ID of the virtual machine.
+* `account` - The account associated with the virtual machine.
+* `display_name` - The user generated name. The name of the virtual machine is returned if no displayname exists.
+* `state` - The state of the virtual machine.
+* `host_id` - The ID of the host for the virtual machine.
+* `zone_id` - The ID of the availablility zone for the virtual machine.
+* `created` - The date when this virtual machine was created.
+* `nic` - The list of nics associated with vm.


### PR DESCRIPTION
This PR adds documentation for the new data sources added in [PR 38 ](https://github.com/apache/cloudstack-terraform-provider/pull/38) to solve GSoC issue: https://github.com/apache/cloudstack/issues/6016