### PR TITLE
Add source_nat_ip_address attribute to cloudstack_network resource

### DIFF
--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -137,6 +137,11 @@ func resourceCloudStackNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"source_nat_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"source_nat_ip_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -282,10 +287,12 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error associating a new IP address: %s", err)
 		}
+		d.Set("source_nat_ip_address", ip.Ipaddress)
 		d.Set("source_nat_ip_id", ip.Id)
 
 		// Set the additional partial
 		d.SetPartial("source_nat_ip")
+		d.SetPartial("source_nat_ip_address")
 		d.SetPartial("source_nat_ip_id")
 	}
 

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -78,6 +78,7 @@ The following attributes are exported:
 * `id` - The ID of the network.
 * `display_text` - The display text of the network.
 * `network_domain` - DNS domain for the network.
+* `source_nat_ip_address` - The associated source NAT IP.
 * `source_nat_ip_id` - The ID of the associated source NAT IP.
 
 ## Import


### PR DESCRIPTION
This PR adds the attribute `source_nat_ip_address` to the `cloudstack_network` resource, which can be passed to provisioner connection blocks (host parameter).

This PR fixes #16 and will save a lot of wasted IP addresses :)
