### PR TITLE
Fix Build Error - Too Many Arguments

### DIFF
--- a/cloudstack/data_source_cloudstack_instance_test.go
+++ b/cloudstack/data_source_cloudstack_instance_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-//basic acceptance to check if the display_name attribute has same value in
-//the created instance and its data source respectively.
+// basic acceptance to check if the display_name attribute has same value in
+// the created instance and its data source respectively.
 func TestAccInstanceDataSource_basic(t *testing.T) {
 	resourceName := "cloudstack_instance.my_instance"
 	datasourceName := "data.cloudstack_instance.my_instance_test"

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -62,7 +62,7 @@ func resourceCloudStackNetworkOfferingCreate(d *schema.ResourceData, meta interf
 	traffic_type := d.Get("traffic_type").(string)
 
 	// Create a new parameter struct
-	p := cs.NetworkOffering.NewCreateNetworkOfferingParams(display_text, guest_ip_type, name, []string{}, traffic_type)
+	p := cs.NetworkOffering.NewCreateNetworkOfferingParams(display_text, guest_ip_type, name, traffic_type)
 
 	if guest_ip_type == "Shared" {
 		p.SetSpecifyvlan(true)


### PR DESCRIPTION
Fix the `"too many arguments in the call to cs.NetworkOffering.NewCreateNetworkOfferingParams"` error by ensuring that the function call at line 65 in `cloudstack/resource_cloudstack_network_offering.go` includes only the required four-string arguments.
Error is:

```
cloudstack/resource_cloudstack_network_offering.go:65:104: too many arguments in call to cs.NetworkOffering.NewCreateNetworkOfferingParams
	have (string, string, string, []string, string)
	want (string, string, string, string)
make: *** [build] Error 2
```