### PR TITLE
Improves service offering resource

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -55,6 +55,15 @@ jobs:
             --data-urlencode 'password=password' \
             --data-urlencode 'response=json' \
             --data-urlencode 'domain=/' -j -c cookies.txt --output /dev/null
+
+          # Create terraform project
+          curl -sf --location "${CLOUDSTACK_API_URL}" \
+            --header 'Content-Type: application/x-www-form-urlencoded' \
+            --data-urlencode 'command=createProject' \
+            --data-urlencode 'name=terraform' \
+            --data-urlencode 'displaytext=terraform' \
+            --data-urlencode 'response=json' -b cookies.txt -j --output /dev/null
+
           CLOUDSTACK_USER_ID=$(curl -fs "${CLOUDSTACK_API_URL}?command=listUsers&response=json" -b cookies.txt | jq -r '.listusersresponse.user[0].id')
           CLOUDSTACK_API_KEY=$(curl -s "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.apikey')
           CLOUDSTACK_SECRET_KEY=$(curl -fs "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.secretkey')

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -85,4 +85,5 @@ jobs:
       matrix:
         cloudstack_version:
           - 4.17.2.0
-          - 4.18.0.0
+          - 4.18.1.0
+          - 4.19.0.0

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -1,0 +1,63 @@
+name: Acceptance Test
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-testacc
+  cancel-in-progress: true
+  
+jobs:
+  testacc:
+    name: Acceptance Test
+    runs-on: ubuntu-22.04
+    env:
+      CLOUDSTACK_API_URL: http://localhost:8080/client/api
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - name: Wait Cloudstack to be ready
+        run: |
+          echo "Starting Cloudstack health check"
+          T=0
+          until [ $T -gt 20 ]  || curl -sfL http://localhost:8080 --output /dev/null
+          do
+            echo "Waiting for Cloudstack to be ready..."
+            ((T+=1))
+            sleep 30
+          done
+      - name: Setting up Cloudstack
+        run: |
+          docker exec $(docker container ls --format=json -l | jq -r .ID) python /root/tools/marvin/marvin/deployDataCenter.py -i /root/setup/dev/advanced.cfg
+          curl -sf --location "${CLOUDSTACK_API_URL}" \
+            --header 'Content-Type: application/x-www-form-urlencoded' \
+            --data-urlencode 'command=login' \
+            --data-urlencode 'username=admin' \
+            --data-urlencode 'password=password' \
+            --data-urlencode 'response=json' \
+            --data-urlencode 'domain=/' -j -c cookies.txt --output /dev/null
+          CLOUDSTACK_USER_ID=$(curl -fs "${CLOUDSTACK_API_URL}?command=listUsers&response=json" -b cookies.txt | jq -r '.listusersresponse.user[0].id')
+          CLOUDSTACK_API_KEY=$(curl -s "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.apikey')
+          CLOUDSTACK_SECRET_KEY=$(curl -fs "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.secretkey')
+          
+          echo "::add-mask::$CLOUDSTACK_API_KEY"
+          echo "::add-mask::$CLOUDSTACK_SECRET_KEY"
+
+          echo "CLOUDSTACK_API_KEY=$CLOUDSTACK_API_KEY" >> $GITHUB_ENV
+          echo "CLOUDSTACK_SECRET_KEY=$CLOUDSTACK_SECRET_KEY" >> $GITHUB_ENV
+      - name: Run acceptance test
+        run: |
+          make testacc
+    services:
+      cloudstack-simulator:
+        image: apache/cloudstack-simulator:${{ matrix.cloudstack_version }}
+        ports:
+          - 8080:5050
+    strategy:
+      matrix:
+        cloudstack_version:
+          - 4.17.2.0
+          - 4.18.0.0
+  

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Acceptance Test
 
 on: [push, pull_request]
@@ -5,7 +22,7 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-testacc
   cancel-in-progress: true
-  
+
 jobs:
   testacc:
     name: Acceptance Test
@@ -41,7 +58,7 @@ jobs:
           CLOUDSTACK_USER_ID=$(curl -fs "${CLOUDSTACK_API_URL}?command=listUsers&response=json" -b cookies.txt | jq -r '.listusersresponse.user[0].id')
           CLOUDSTACK_API_KEY=$(curl -s "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.apikey')
           CLOUDSTACK_SECRET_KEY=$(curl -fs "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.secretkey')
-          
+
           echo "::add-mask::$CLOUDSTACK_API_KEY"
           echo "::add-mask::$CLOUDSTACK_SECRET_KEY"
 
@@ -60,4 +77,3 @@ jobs:
         cloudstack_version:
           - 4.17.2.0
           - 4.18.0.0
-  

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -56,14 +56,6 @@ jobs:
             --data-urlencode 'response=json' \
             --data-urlencode 'domain=/' -j -c cookies.txt --output /dev/null
 
-          # Create terraform project
-          curl -sf --location "${CLOUDSTACK_API_URL}" \
-            --header 'Content-Type: application/x-www-form-urlencoded' \
-            --data-urlencode 'command=createProject' \
-            --data-urlencode 'name=terraform' \
-            --data-urlencode 'displaytext=terraform' \
-            --data-urlencode 'response=json' -b cookies.txt -j --output /dev/null
-
           CLOUDSTACK_USER_ID=$(curl -fs "${CLOUDSTACK_API_URL}?command=listUsers&response=json" -b cookies.txt | jq -r '.listusersresponse.user[0].id')
           CLOUDSTACK_API_KEY=$(curl -s "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.apikey')
           CLOUDSTACK_SECRET_KEY=$(curl -fs "${CLOUDSTACK_API_URL}?command=getUserKeys&id=${CLOUDSTACK_USER_ID}&response=json" -b cookies.txt | jq -r '.getuserkeysresponse.userkeys.secretkey')
@@ -73,6 +65,13 @@ jobs:
 
           echo "CLOUDSTACK_API_KEY=$CLOUDSTACK_API_KEY" >> $GITHUB_ENV
           echo "CLOUDSTACK_SECRET_KEY=$CLOUDSTACK_SECRET_KEY" >> $GITHUB_ENV
+      - name: Install CMK
+        run: |
+          curl -sfL https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.3.0/cmk.linux.x86-64 -o /usr/local/bin/cmk
+          chmod +x /usr/local/bin/cmk
+      - name: Create extra resources
+        run: |
+          cmk -u $CLOUDSTACK_API_URL -k $CLOUDSTACK_API_KEY -s $CLOUDSTACK_SECRET_KEY -o json create project name=terraform displaytext=terraform
       - name: Run acceptance test
         run: |
           make testacc

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ $ make test
 In order to run the full suite of Acceptance tests you will need to run the CloudStack Simulator. Please follow these steps to prepare an environment for running the Acceptance tests:
 
 ```sh
-$ docker pull cloudstack/simulator
-$ docker run --name simulator -p 8080:5050 -d cloudstack/simulator
+$ docker pull apache/cloudstack-simulator
+$ docker run --name cloudstack-simulator -p 8080:5050 -d apache/cloudstack-simulator
 ```
 
 When Docker started the container you can go to http://localhost:8080/client and login to the CloudStack UI as user `admin` with password `password`. It can take a few minutes for the container is fully ready, so you probably need to wait and refresh the page for a few minutes before the login page is shown.
@@ -74,7 +74,7 @@ When Docker started the container you can go to http://localhost:8080/client and
 Once the login page is shown and you can login, you need to provision a simulated data-center:
 
 ```sh
-$ docker exec -ti cloudstack python /root/tools/marvin/marvin/deployDataCenter.py -i /root/setup/dev/advanced.cfg
+docker exec -it cloudstack-simulator python /root/tools/marvin/marvin/deployDataCenter.py -i /root/setup/dev/advanced.cfg
 ```
 
 If you refresh the client or login again, you will now get passed the initial welcome screen and be able to go to your account details and retrieve the API key and secret. Export those together with the URL:

--- a/cloudstack/resource_cloudstack_service_offering.go
+++ b/cloudstack/resource_cloudstack_service_offering.go
@@ -84,7 +84,7 @@ func resourceCloudStackServiceOffering() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     "local",
+				Default:     "shared",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 

--- a/cloudstack/resource_cloudstack_service_offering_test.go
+++ b/cloudstack/resource_cloudstack_service_offering_test.go
@@ -1,0 +1,85 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccCloudStackServiceOffering_basic(t *testing.T) {
+	var so cloudstack.ServiceOffering
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackServiceOffering_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackServiceOfferingExists("cloudstack_service_offering.test1", &so),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.test1", "cpu_number", "2"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.test1", "cpu_speed", "2200"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.test1", "memory", "8096"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackServiceOffering_basic = `
+resource "cloudstack_service_offering" "test1" {
+  name 			= "service_offering_1"
+  display_text 	= "Test"
+  cpu_number	= 2
+  cpu_speed		= 2200
+  memory        = 8096
+}
+`
+
+func testAccCheckCloudStackServiceOfferingExists(n string, so *cloudstack.ServiceOffering) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No service offering ID is set")
+		}
+
+		cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+		resp, _, err := cs.ServiceOffering.GetServiceOfferingByID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp.Id != rs.Primary.ID {
+			return fmt.Errorf("Service offering not found")
+		}
+
+		*so = *resp
+
+		return nil
+	}
+}

--- a/website/docs/r/service_offering.html.markdown
+++ b/website/docs/r/service_offering.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_service_offering"
+sidebar_current: "docs-cloudstack-resource-service-offering"
+description: |-
+  Creates a service offering.
+---
+
+# cloudstack_service_offering
+
+Creates a service offering.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "cloudstack_service_offering" "default" {
+    name       = "Small"
+    cpu_number = 2
+    cpu_speed  = 1000
+    memory     = 4096
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the service offering.
+    Changing this forces a new resource to be created.
+
+* `display_text` - (Optional) The display text of the service offering.
+
+* `cpu_number` - (Optional) The number of CPU cores.
+    Changing this forces a new resource to be created.
+
+* `cpu_speed` - (Optional) The speed of the CPU in Mhz.
+    Changing this forces a new resource to be created.
+
+* `memory` - (Optional) Memory reserved by the VM in MB.
+    Changing this forces a new resource to be created.
+
+* `host_tags` - (Optional) The host tags for the service offering.
+
+* `limit_cpu_use` - (Optional) Restrict the CPU usage to committed service offering.
+    Changing this forces a new resource to be created.
+
+* `offer_ha` - (Optional) The HA for the service offering.
+    Changing this forces a new resource to be created.
+
+* `storage_type` - (Optional) The storage type of the service offering. Values are `local` and `shared`.
+    Changing this forces a new resource to be created.
+    
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the service offering.


### PR DESCRIPTION
Hi,

Here is some improvement in the `cloudstack_service_offering` resource so we can specify the `cpu_number`, `cpu_speed` and `memory` now.

I've added the acceptance test CI which can be run with different versions of Cloudstack. Although it is failing, the specific test for this change is passing:

```
=== RUN   TestAccCloudStackServiceOffering_basic
--- PASS: TestAccCloudStackServiceOffering_basic (0.33s)
```

Also, I made a change in the README to include the updated version of the `cloudstack-simulator`.