### PR TITLE
Enhancing zone resource

### DIFF
--- a/cloudstack/resource_cloudstack_zone.go
+++ b/cloudstack/resource_cloudstack_zone.go
@@ -20,8 +20,8 @@
 package cloudstack
 
 import (
+	"errors"
 	"fmt"
-	"log"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -34,15 +34,63 @@ func resourceCloudStackZone() *schema.Resource {
 		Update: resourceCloudStackZoneUpdate,
 		Delete: resourceCloudStackZoneDelete,
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"allocationstate": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dhcp_provider": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"dns1": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"dns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domainid": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"guestcidraddress": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"internal_dns1": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internal_dns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip6dns1": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip6dns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"localstorageenabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -50,70 +98,153 @@ func resourceCloudStackZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"securitygroupenabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
 
 func resourceCloudStackZoneCreate(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
-	name := d.Get("name").(string)
-	dns1 := d.Get("dns1").(string)
-	internal_dns1 := d.Get("internal_dns1").(string)
-	network_type := d.Get("network_type").(string)
 
-	// Create a new parameter struct
-	p := cs.Zone.NewCreateZoneParams(dns1, internal_dns1, name, network_type)
+	// Create a new parameters
+	p := cs.Zone.NewCreateZoneParams(d.Get("dns1").(string), d.Get("internal_dns1").(string), d.Get("name").(string), d.Get("network_type").(string))
+	if v, ok := d.GetOk("allocationstate"); ok {
+		p.SetAllocationstate(v.(string))
+	}
+	if v, ok := d.GetOk("dns2"); ok {
+		p.SetDns2(v.(string))
+	}
+	if v, ok := d.GetOk("domain"); ok {
+		p.SetDomain(v.(string))
+	}
+	if v, ok := d.GetOk("domainid"); ok {
+		p.SetDomainid(v.(string))
+	}
+	if v, ok := d.GetOk("guestcidraddress"); ok {
+		p.SetGuestcidraddress(v.(string))
+	}
+	if v, ok := d.GetOk("internal_dns2"); ok {
+		p.SetInternaldns2(v.(string))
+	}
+	if v, ok := d.GetOk("ip6dns1"); ok {
+		p.SetIp6dns1(v.(string))
+	}
+	if v, ok := d.GetOk("ip6dns2"); ok {
+		p.SetIp6dns2(v.(string))
+	}
+	if v, ok := d.GetOk("localstorageenabled"); ok {
+		p.SetLocalstorageenabled(v.(bool))
+	}
+	if v, ok := d.GetOk("securitygroupenabled"); ok {
+		p.SetSecuritygroupenabled(v.(bool))
+	}
 
-	log.Printf("[DEBUG] Creating Zone %s", name)
-	n, err := cs.Zone.CreateZone(p)
-
+	// Create zone
+	r, err := cs.Zone.CreateZone(p)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Zone %s successfully created", name)
-	d.SetId(n.Id)
+	d.SetId(r.Id)
 
 	return resourceCloudStackZoneRead(d, meta)
 }
 
 func resourceCloudStackZoneRead(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
-	log.Printf("[DEBUG] Retrieving Zone %s", d.Get("name").(string))
 
-	// Get the Zone details
-	z, count, err := cs.Zone.GetZoneByName(d.Get("name").(string))
-
+	z, count, err := cs.Zone.GetZoneByID(d.Id())
 	if err != nil {
-		if count == 0 {
-			log.Printf("[DEBUG] Zone %s does no longer exist", d.Get("name").(string))
-			d.SetId("")
-			return nil
-		}
 		return err
 	}
+	if count != 1 {
+		return errors.New(fmt.Sprintf("Multiple zones.  Invalid zone id: %s", d.Id()))
+	}
 
-	d.SetId(z.Id)
-	d.Set("name", z.Name)
+	d.Set("allocationstate", z.Allocationstate)
+	d.Set("description", z.Description)
+	d.Set("dhcp_provider", z.Dhcpprovider)
 	d.Set("dns1", z.Dns1)
+	d.Set("dns2", z.Dns2)
+	d.Set("domain", z.Domain)
+	d.Set("domainid", z.Domainid)
+	d.Set("guestcidraddress", z.Guestcidraddress)
 	d.Set("internal_dns1", z.Internaldns1)
+	d.Set("internal_dns2", z.Internaldns2)
+	d.Set("ip6dns1", z.Ip6dns1)
+	d.Set("ip6dns2", z.Ip6dns2)
+	d.Set("localstorageenabled", z.Localstorageenabled)
+	d.Set("name", z.Name)
 	d.Set("network_type", z.Networktype)
+	d.Set("securitygroupenabled", z.Securitygroupsenabled)
 
 	return nil
 }
 
-func resourceCloudStackZoneUpdate(d *schema.ResourceData, meta interface{}) error { return nil }
+func resourceCloudStackZoneUpdate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	p := cs.Zone.NewUpdateZoneParams(d.Id())
+
+	if v, ok := d.GetOk("allocationstate"); ok {
+		p.SetAllocationstate(v.(string))
+	}
+	if v, ok := d.GetOk("dhcp_provider"); ok {
+		p.SetDhcpprovider(v.(string))
+	}
+	if v, ok := d.GetOk("dns1"); ok {
+		p.SetDns1(v.(string))
+	}
+	if v, ok := d.GetOk("dns2"); ok {
+		p.SetDns2(v.(string))
+	}
+	if v, ok := d.GetOk("domain"); ok {
+		p.SetDomain(v.(string))
+	}
+	if v, ok := d.GetOk("guestcidraddress"); ok {
+		p.SetGuestcidraddress(v.(string))
+	}
+
+	if v, ok := d.GetOk("internal_dns1"); ok {
+		p.SetInternaldns1(v.(string))
+	}
+	if v, ok := d.GetOk("internal_dns2"); ok {
+		p.SetInternaldns2(v.(string))
+	}
+	if v, ok := d.GetOk("ip6dns1"); ok {
+		p.SetIp6dns1(v.(string))
+	}
+	if v, ok := d.GetOk("ip6dns2"); ok {
+		p.SetIp6dns2(v.(string))
+	}
+	if v, ok := d.GetOk("localstorageenabled"); ok {
+		p.SetLocalstorageenabled(v.(bool))
+	}
+	if v, ok := d.GetOk("name"); ok {
+		p.SetName(v.(string))
+	}
+
+	_, err := cs.Zone.UpdateZone(p)
+	if err != nil {
+		return err
+	}
+
+	return resourceCloudStackZoneRead(d, meta)
+}
 
 func resourceCloudStackZoneDelete(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
-	// Create a new parameter struct
-	p := cs.Zone.NewDeleteZoneParams(d.Id())
-	_, err := cs.Zone.DeleteZone(p)
-
+	// Delete zone
+	_, err := cs.Zone.DeleteZone(cs.Zone.NewDeleteZoneParams(d.Id()))
 	if err != nil {
 		return fmt.Errorf("Error deleting Zone: %s", err)
 	}
+
+	d.SetId("")
 
 	return nil
 }

--- a/cloudstack/resource_cloudstack_zone.go
+++ b/cloudstack/resource_cloudstack_zone.go
@@ -33,6 +33,9 @@ func resourceCloudStackZone() *schema.Resource {
 		Read:   resourceCloudStackZoneRead,
 		Update: resourceCloudStackZoneUpdate,
 		Delete: resourceCloudStackZoneDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"allocationstate": {
 				Type:     schema.TypeString,

--- a/cloudstack/resource_cloudstack_zone_test.go
+++ b/cloudstack/resource_cloudstack_zone_test.go
@@ -45,14 +45,13 @@ func TestAccCloudStackZone_basic(t *testing.T) {
 
 const testAccCloudStackZone_basic = `
 resource "cloudstack_zone" "test" {
-    name          = "acctest"
-    dns1          = "8.8.8.8"
-    dns2          = "8.8.8.8"
-    internal_dns1 = "8.8.4.4"
-    internal_dns2 = "8.8.4.4"
-    network_type  = "Advanced"
-    domain        = "foo.cloudstack.com"
-	
+	name          = "acctest"
+	dns1          = "8.8.8.8"
+	dns2          = "8.8.8.8"
+	internal_dns1 = "8.8.4.4"
+	internal_dns2 = "8.8.4.4"
+	network_type  = "Advanced"
+	domain        = "cloudstack.apache.org"
 }
 `
 
@@ -60,13 +59,13 @@ resource "cloudstack_zone" "test" {
 
 const testAccCloudStackZone_update = `
 resource "cloudstack_zone" "test" {
-    name             = "acctestupdated"
-    dns1             = "8.8.4.4"
-    dns2             = "8.8.4.4"
-    internal_dns1    = "8.8.8.8"
-    internal_dns2    = "8.8.8.8"
-    network_type     = "Advanced"
-    domain           = "foo.cloudstack.com"
+	name             = "acctestupdated"
+	dns1             = "8.8.4.4"
+	dns2             = "8.8.4.4"
+	internal_dns1    = "8.8.8.8"
+	internal_dns2    = "8.8.8.8"
+	network_type     = "Advanced"
+	domain           = "cloudstack.apache.org"
 	guestcidraddress = "172.29.2.0/20"
 }
 `

--- a/cloudstack/resource_cloudstack_zone_test.go
+++ b/cloudstack/resource_cloudstack_zone_test.go
@@ -1,0 +1,72 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccCloudStackZone_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackZone_basic,
+			},
+			{
+				Config: testAccCloudStackZone_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_zone.test", "name", "acctestupdated"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackZone_basic = `
+resource "cloudstack_zone" "test" {
+    name          = "acctest"
+    dns1          = "8.8.8.8"
+    dns2          = "8.8.8.8"
+    internal_dns1 = "8.8.4.4"
+    internal_dns2 = "8.8.4.4"
+    network_type  = "Advanced"
+    domain        = "foo.cloudstack.com"
+	
+}
+`
+
+// guestcidraddress = "172.29.1.0/20"
+
+const testAccCloudStackZone_update = `
+resource "cloudstack_zone" "test" {
+    name             = "acctestupdated"
+    dns1             = "8.8.4.4"
+    dns2             = "8.8.4.4"
+    internal_dns1    = "8.8.8.8"
+    internal_dns2    = "8.8.8.8"
+    network_type     = "Advanced"
+    domain           = "foo.cloudstack.com"
+	guestcidraddress = "172.29.2.0/20"
+}
+`


### PR DESCRIPTION
Updating Zone resource
- Added all fields
- set terraform id as zone id instead of zone name.
- added support for updating the zone


Note: this requires the latest cloudstack-go client.
https://github.com/apache/cloudstack-go/pull/68


