### PR TITLE
Add UEFI support

### DIFF
--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -154,6 +154,12 @@ func resourceCloudStackInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"uefi": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"start_vm": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -275,6 +281,11 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	// If there is a root_disk_size supplied, add it to the parameter struct
 	if rootdisksize, ok := d.GetOk("root_disk_size"); ok {
 		p.SetRootdisksize(int64(rootdisksize.(int)))
+	}
+
+	if d.Get("uefi").(bool) {
+		p.SetBoottype("UEFI")
+		p.SetBootmode("Legacy")
 	}
 
 	if zone.Networktype == "Advanced" {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
 * `expunge` - (Optional) This determines if the instance is expunged when it is
     destroyed (defaults false)
 
+* `uefi` - (Optional) When set, will boot the instance in UEFI/Legacy mode (defaults false)
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This adds a new boolean parameter to the cloudstack_instance resource, called "uefi". When set, the instance will boot in UEFI/Legacy mode.