### PR TITLE
Added encrypt and tags option to disk offering

### DIFF
--- a/cloudstack/resource_cloudstack_disk_offering.go
+++ b/cloudstack/resource_cloudstack_disk_offering.go
@@ -45,6 +45,16 @@ func resourceCloudStackDiskOffering() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"encrypt": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -58,6 +68,14 @@ func resourceCloudStackDiskOfferingCreate(d *schema.ResourceData, meta interface
 	// Create a new parameter struct
 	p := cs.DiskOffering.NewCreateDiskOfferingParams(name, display_text)
 	p.SetDisksize(int64(disk_size))
+
+	p.SetDisksize(int64(disk_size))
+	if encrypt, ok := d.GetOk("encrypt"); ok {
+		p.SetEncrypt(encrypt.(bool))
+	}
+	if tags, ok := d.GetOk("tags"); ok {
+		p.SetTags(tags.(string))
+	}
 
 	log.Printf("[DEBUG] Creating Disk Offering %s", name)
 	diskOff, err := cs.DiskOffering.CreateDiskOffering(p)
@@ -76,4 +94,16 @@ func resourceCloudStackDiskOfferingRead(d *schema.ResourceData, meta interface{}
 
 func resourceCloudStackDiskOfferingUpdate(d *schema.ResourceData, meta interface{}) error { return nil }
 
-func resourceCloudStackDiskOfferingDelete(d *schema.ResourceData, meta interface{}) error { return nil }
+func resourceCloudStackDiskOfferingDelete(d *schema.ResourceData, meta interface{}) error { 
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	p := cs.DiskOffering.NewDeleteDiskOfferingParams(d.Id())
+	_, err := cs.DiskOffering.DeleteDiskOffering(p)
+	if err != nil {
+		return fmt.Errorf("Error deleting disk offering: %s", err)
+	}
+	
+	
+	return nil
+
+}

--- a/website/docs/r/disk_offering.html.markdown
+++ b/website/docs/r/disk_offering.html.markdown
@@ -28,6 +28,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the disk offering.
 * `display_text` - (Required) The display text of the disk offering.
 * `disk_size` - (Required) The size of the disk offering in GB.
+* `encrypt` - (Optional)  Volumes using this offering should be encrypted
+* `tags` - (Optional)  tags for the disk offering
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR

Adds support to create disk offering by introducing the encrypt and tags option 

https://cloudstack.apache.org/api/apidocs-4.19/apis/createDiskOffering.html

And supports the destroy of disk offering

The only prerequisite is that cloudstack sdk  should be v2.15.0

https://github.com/apache/cloudstack-terraform-provider/pull/71