### PR TITLE
added noderootdisksize parameter

### DIFF
--- a/cloudstack/resource_cloudstack_kubernetes_cluster.go
+++ b/cloudstack/resource_cloudstack_kubernetes_cluster.go
@@ -126,6 +126,12 @@ func resourceCloudStackKubernetesCluster() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"noderootdisksize": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  8,
+			},
 		},
 	}
 }
@@ -170,6 +176,9 @@ func resourceCloudStackKubernetesClusterCreate(d *schema.ResourceData, meta inte
 	}
 	if controlNodesSize, ok := d.GetOk("control_nodes_size"); ok {
 		p.SetControlnodes(int64(controlNodesSize.(int)))
+	}
+	if noderootdisksize, ok := d.GetOk("noderootdisksize"); ok {
+		p.SetNoderootdisksize(int64(noderootdisksize.(int)))
 	}
 
 	// If there is a project supplied, we retrieve and set the project id

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -51,6 +51,7 @@ The following arguments are supported:
 * `ip_address` - (Computed) The IP address of the Kubernetes cluster.
 * `state` - (Optional) The state of the Kubernetes cluster. Defaults to `"Running"`.
 * `project` - (Optional) The project to assign the Kubernetes cluster to.
+* `noderootdisksize` - (Optional) root disk size in GB for each node.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR fixes #41 


https://cloudstack.apache.org/api/apidocs-4.19/apis/createKubernetesCluster.html

noderootdisksize` - (Optional) root disk size in GB for each node