### PR TITLE
fix: remove user-data conditional size

### DIFF
--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -373,7 +373,7 @@ func resourceCloudStackInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if userData, ok := d.GetOk("user_data"); ok {
-		ud, err := getUserData(userData.(string), cs.HTTPGETOnly)
+		ud, err := getUserData(userData.(string))
 		if err != nil {
 			return err
 		}
@@ -656,7 +656,7 @@ func resourceCloudStackInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 		if d.HasChange("user_data") {
 			log.Printf("[DEBUG] user_data changed for %s, starting update", name)
 
-			ud, err := getUserData(d.Get("user_data").(string), cs.HTTPGETOnly)
+			ud, err := getUserData(d.Get("user_data").(string))
 			if err != nil {
 				return err
 			}
@@ -733,24 +733,10 @@ func resourceCloudStackInstanceImport(d *schema.ResourceData, meta interface{}) 
 }
 
 // getUserData returns the user data as a base64 encoded string
-func getUserData(userData string, httpGetOnly bool) (string, error) {
+func getUserData(userData string) (string, error) {
 	ud := userData
 	if _, err := base64.StdEncoding.DecodeString(ud); err != nil {
 		ud = base64.StdEncoding.EncodeToString([]byte(userData))
-	}
-
-	// deployVirtualMachine uses POST by default, so max userdata is 32K
-	maxUD := 32768
-
-	if httpGetOnly {
-		// deployVirtualMachine using GET instead, so max userdata is 2K
-		maxUD = 2048
-	}
-
-	if len(ud) > maxUD {
-		return "", fmt.Errorf(
-			"The supplied user_data contains %d bytes after encoding, "+
-				"this exceeds the limit of %d bytes", len(ud), maxUD)
 	}
 
 	return ud, nil

--- a/cloudstack/resource_cloudstack_instance_test.go
+++ b/cloudstack/resource_cloudstack_instance_test.go
@@ -21,6 +21,7 @@ package cloudstack
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
@@ -207,6 +208,26 @@ func TestAccCloudStackInstance_importProject(t *testing.T) {
 				ImportStateIdPrefix:     "terraform/",
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"expunge", "user_data", "uefi"},
+			},
+		},
+	})
+}
+
+func TestAccCloudStackInstance_userData(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackInstanceDestroy,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				VersionConstraint: ">= 3.6.0",
+				Source:            "hashicorp/random",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCloudStackInstance_userData,
+				ExpectError: regexp.MustCompile("User data has exceeded configurable max length"),
 			},
 		},
 	})
@@ -435,4 +456,34 @@ resource "cloudstack_instance" "foobar" {
   project = "terraform"
   zone = cloudstack_network.foo.zone
   expunge = true
+}`
+
+const testAccCloudStackInstance_userData = `
+resource "random_bytes" "string" {
+  length = 32768
+}
+
+resource "cloudstack_network" "foo" {
+  name = "terraform-network"
+  display_text = "terraform-network"
+  cidr = "10.1.1.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone = "Sandbox-simulator"
+}
+
+resource "cloudstack_instance" "foobar" {
+  name = "terraform-test"
+  display_name = "terraform-test"
+  service_offering= "Small Instance"
+  network_id = cloudstack_network.foo.id
+  template = "CentOS 5.6 (64-bit) no GUI (Simulator)"
+  zone = cloudstack_network.foo.zone
+  expunge = true
+  user_data = <<-EOFTF
+#!/bin/bash
+
+echo <<EOF
+${random_bytes.string.base64}
+EOF
+EOFTF
 }`


### PR DESCRIPTION
Removes de fixed max size for user-data on the creation of the instance. As this value is configurable in the Cloudstack backend, provider will handover the conditional check to the Cloudstack management.