### PR TITLE
ci: runs acc test on every change

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,17 +19,7 @@ name: Acceptance Test
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/acceptance.yml
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
   push:
-    paths:
-      - .github/workflows/acceptance.yml
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-acceptance

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,10 +22,14 @@ on:
     paths:
       - .github/workflows/acceptance.yml
       - '**.go'
+      - 'go.mod'
+      - 'go.sum'
   push:
     paths:
       - .github/workflows/acceptance.yml
       - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-acceptance


### PR DESCRIPTION
Runs the Acceptance Tests when the `go.mod` and `go.sum` get changed. This will allow testing the dependency updates, specially by dependabot.