### PR TITLE
feat: add cidrlist parameter to loadbalancer rule

### DIFF
--- a/cloudstack/resource_cloudstack_loadbalancer_rule.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule.go
@@ -22,6 +22,7 @@ package cloudstack
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -97,6 +98,14 @@ func resourceCloudStackLoadBalancerRule() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"cidrlist": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -141,6 +150,16 @@ func resourceCloudStackLoadBalancerRuleCreate(d *schema.ResourceData, meta inter
 	// Set the protocol
 	if protocol, ok := d.GetOk("protocol"); ok {
 		p.SetProtocol(protocol.(string))
+	}
+
+	// Set CIDR list
+	if cidr, ok := d.GetOk("cidrlist"); ok {
+		var cidrList []string
+		for _, id := range cidr.(*schema.Set).List() {
+			cidrList = append(cidrList, id.(string))
+		}
+
+		p.SetCidrlist(cidrList)
 	}
 
 	// Set the ipaddress id
@@ -215,6 +234,12 @@ func resourceCloudStackLoadBalancerRuleRead(d *schema.ResourceData, meta interfa
 	d.Set("public_port", public_port)
 	d.Set("private_port", private_port)
 	d.Set("protocol", lb.Protocol)
+
+	// Only set cidr if user specified it to avoid spurious diffs
+	delimiters := regexp.MustCompile(`\s*,\s*|\s+`)
+	if _, ok := d.GetOk("cidrlist"); ok {
+		d.Set("cidrlist", delimiters.Split(lb.Cidrlist, -1))
+	}
 
 	// Only set network if user specified it to avoid spurious diffs
 	if _, ok := d.GetOk("network_id"); ok {

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -129,6 +129,8 @@ func TestAccCloudStackLoadBalancerRule_forceNew(t *testing.T) {
 						"cloudstack_loadbalancer_rule.foo", "private_port", "443"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_loadbalancer_rule.foo", "protocol", "tcp-proxy"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "cidrlist.0", "20.0.0.0/8"),
 				),
 			},
 		},
@@ -192,6 +194,8 @@ func TestAccCloudStackLoadBalancerRule_vpcUpdate(t *testing.T) {
 						"cloudstack_loadbalancer_rule.foo", "public_port", "443"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_loadbalancer_rule.foo", "private_port", "443"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_loadbalancer_rule.foo", "cidrlist.0", "20.0.0.0/8"),
 				),
 			},
 		},
@@ -357,6 +361,7 @@ resource "cloudstack_loadbalancer_rule" "foo" {
   private_port = 443
   protocol = "tcp-proxy"
   member_ids = [cloudstack_instance.foobar1.id]
+  cidrlist = ["20.0.0.0/8"]
 }`
 
 const testAccCloudStackLoadBalancerRule_vpc = `
@@ -451,4 +456,5 @@ resource "cloudstack_loadbalancer_rule" "foo" {
   public_port = 443
   private_port = 443
   member_ids = [cloudstack_instance.foobar1.id, cloudstack_instance.foobar2.id]
+  cidrlist = ["20.0.0.0/8"]
 }`

--- a/website/docs/r/loadbalancer_rule.html.markdown
+++ b/website/docs/r/loadbalancer_rule.html.markdown
@@ -21,6 +21,7 @@ resource "cloudstack_loadbalancer_rule" "default" {
   private_port  = 80
   public_port   = 80
   member_ids    = ["f8141e2f-4e7e-4c63-9362-986c908b7ea7"]
+  cidrlist      = ["12.34.56.78/30","99.99.99.99/32"]
 }
 ```
 
@@ -57,6 +58,8 @@ The following arguments are supported:
 
 * `member_ids` - (Required) List of instance IDs to assign to the load balancer
     rule. Changing this forces a new resource to be created.
+
+* `cidrlist` - (Optional) A CIDR list to allow access to the given ports.
 
 * `project` - (Optional) The name or ID of the project to deploy this
     instance to. Changing this forces a new resource to be created.


### PR DESCRIPTION
**Actual behaviour:**

CIDR list parameter is critical feature when it comes to loadbalancer rules and it is missing at the moment.
When you create a loadbalancer rule using resource, it allows all CIDRs, which is not indented every time.


**What was updated?**

Added cidrlist parameter to loadbalancer_rule resource, so we can create rules with specific CIDRs instead of allowing everyone to access loadbalancer.

Would be great if you guys could release a new version of provider even as a minor which include this feature.