### PR TITLE
Add `acl_id` parameter to the example usage of the `cloudstack_private_gateway` resource

### DIFF
--- a/website/docs/r/private_gateway.html.markdown
+++ b/website/docs/r/private_gateway.html.markdown
@@ -21,6 +21,7 @@ resource "cloudstack_private_gateway" "default" {
   netmask    = "255.255.255.252"
   vlan       = "200"
   vpc_id     = "76f6e8dc-07e3-4971-b2a2-8831b0cc4cb4"
+  acl_id     = "cf4f1dad-aade-4ccd-866c-0a2166e5be3d"
 }
 ```
 


### PR DESCRIPTION
The [example usage](https://registry.terraform.io/providers/cloudstack/cloudstack/latest/docs/resources/private_gateway#example-usage) of the `cloudstack_private_gateway` resource lacks the required `acl_id` parameter. This PR adds the required parameter to the example usage.