### PR TITLE
Update Cloudstack and Terraform versions in acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   CLOUDSTACK_API_URL: http://localhost:8080/client/api
-  CLOUDSTACK_VERSIONS: "['4.18.2.1', '4.19.0.2']"
+  CLOUDSTACK_VERSIONS: "['4.18.2.1', '4.19.3.0', '4.20.1.0']"
 
 jobs:
   prepare-matrix:
@@ -78,8 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform-version:
-          - '1.8.*'
-          - '1.9.*'
+          - '1.11.*'
+          - '1.12.*'
         cloudstack-version: ${{ fromJson(needs.prepare-matrix.outputs.cloudstack-versions) }}
 
   acceptance-opentofu:
@@ -116,8 +116,8 @@ jobs:
       fail-fast: false
       matrix:
         opentofu-version:
-          - '1.6.*'
-          - '1.7.*'
+          - '1.8.*'
+          - '1.9.*'
         cloudstack-version: ${{ fromJson(needs.prepare-matrix.outputs.cloudstack-versions) }}
 
   all-jobs-passed: # Will succeed if it is skipped

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -58,6 +58,7 @@ jobs:
         id: setup-cloudstack
         with:
           cloudstack-version: ${{ matrix.cloudstack-version }}
+          debug: 'true'
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.terraform-version }}
@@ -97,6 +98,7 @@ jobs:
         id: setup-cloudstack
         with:
           cloudstack-version: ${{ matrix.cloudstack-version }}
+          debug: 'true'
       - uses: opentofu/setup-opentofu@v1
         with:
           tofu_version: ${{ matrix.opentofu-version }}

--- a/.github/workflows/setup-cloudstack/action.yml
+++ b/.github/workflows/setup-cloudstack/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Install CMK
       shell: bash
       run: |
-        curl -sfL https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.3.0/cmk.linux.x86-64 -o /usr/local/bin/cmk
+        curl -sfL https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.4.0/cmk.linux.x86-64 -o /usr/local/bin/cmk
         chmod +x /usr/local/bin/cmk
     - name: Create extra resources
       shell: bash

--- a/.github/workflows/setup-cloudstack/action.yml
+++ b/.github/workflows/setup-cloudstack/action.yml
@@ -16,11 +16,16 @@
 # under the License.
 
 name: Setup Cloudstack
+description: 'Sets up CloudStack environment for testing and development'
 
 inputs:
   cloudstack-version:
     description: 'Cloudstack version'
     required: true
+  debug:
+    description: 'Enable debug mode for troubleshooting'
+    required: false
+    default: 'false'
 outputs:
   CLOUDSTACK_USER_ID:
     description: 'Cloudstack user id'
@@ -49,6 +54,24 @@ runs:
             ((T+=1))
             sleep 30
         done
+    - name: Docker Troubleshooting
+      if: ${{ inputs.debug == 'true' }}
+      shell: bash
+      run: |
+        echo "=== Docker Troubleshooting Information ==="
+        echo "Running docker images to list all available images"
+        docker images
+        
+        echo "Running docker ps -a to show all containers (including stopped ones)"
+        docker ps -a
+        
+        echo "Capturing logs from all running containers"
+        for container_id in $(docker ps -q); do
+          echo "=== Logs for container $container_id ==="
+          docker logs $container_id
+        done
+        
+        echo "=== End of Docker Troubleshooting ==="
     - name: Setting up Cloudstack
       id: setup-cloudstack
       shell: bash


### PR DESCRIPTION
Addressing #189

I think this is all that needs to be done.
Our DEV environment and soon PROD Cloudstack will need `4.20.1.0` and I am bumping OpenTofu and Terraform to the last 2 releases.



Ref:
https://cloudstack.apache.org/blog/cloudstack-4.19.3.0-4.20.1.0-release/