### PR TITLE
Support desc and ruleId in create_network_acl_rule

### DIFF
--- a/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -57,7 +57,7 @@ func resourceCloudStackNetworkACLRule() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"rule_id": {
+						"rule_number": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
@@ -210,7 +210,7 @@ func createNetworkACLRule(d *schema.ResourceData, meta interface{}, rule map[str
 	p := cs.NetworkACL.NewCreateNetworkACLParams(rule["protocol"].(string))
 
 	// If a rule ID is specified, set it
-	if ruleId, ok := rule["rule_id"].(int); ok && ruleId > 0 {
+	if ruleId, ok := rule["rule_number"].(int); ok && ruleId > 0 {
 		p.SetNumber(ruleId)
 	}
 
@@ -644,12 +644,12 @@ func verifyNetworkACLParams(d *schema.ResourceData) error {
 }
 
 func verifyNetworkACLRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
-	if ruleId, ok := rule["rule_id"]; ok && ruleId != nil {
-		if rId, ok := ruleId.(int); ok && rId != 0 {
-			// Validate only if rule_id is explicitly set (non-zero)
+	if ruleNum, ok := rule["rule_number"]; ok && ruleNum != nil {
+		if rId, ok := ruleNum.(int); ok && rId != 0 {
+			// Validate only if rule_number is explicitly set (non-zero)
 			if rId < 1 || rId > 65535 {
 				return fmt.Errorf(
-					"%q must be between %d and %d inclusive, got: %d", "rule_id", 1, 65535, rId)
+					"%q must be between %d and %d inclusive, got: %d", "rule_number", 1, 65535, rId)
 			}
 		}
 	}

--- a/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -645,7 +645,8 @@ func verifyNetworkACLParams(d *schema.ResourceData) error {
 
 func verifyNetworkACLRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
 	if ruleId, ok := rule["rule_id"]; ok && ruleId != nil {
-		if rId, ok := ruleId.(int); ok && rId > 0 {
+		if rId, ok := ruleId.(int); ok && rId != 0 {
+			// Validate only if rule_id is explicitly set (non-zero)
 			if rId < 1 || rId > 65535 {
 				return fmt.Errorf(
 					"%q must be between %d and %d inclusive, got: %d", "rule_id", 1, 65535, rId)

--- a/cloudstack/resource_cloudstack_network_acl_rule_test.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule_test.go
@@ -86,6 +86,8 @@ func TestAccCloudStackNetworkACLRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.#", "3"),
 					resource.TestCheckResourceAttr(
+						"cloudstack_network_acl_rule.foo", "rule.0.number", "10"),
+					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.0.action", "allow"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.0.cidr_list.0", "172.16.100.0/24"),
@@ -100,6 +102,10 @@ func TestAccCloudStackNetworkACLRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.0.traffic_type", "ingress"),
 					resource.TestCheckResourceAttr(
+						"cloudstack_network_acl_rule.foo", "rule.0.reason", "Allow all traffic"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_network_acl_rule.foo", "rule.1.number", "20"),
+					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.1.action", "allow"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.1.cidr_list.#", "1"),
@@ -111,6 +117,10 @@ func TestAccCloudStackNetworkACLRule_update(t *testing.T) {
 						"cloudstack_network_acl_rule.foo", "rule.1.icmp_type", "-1"),
 					resource.TestCheckResourceAttr(
 						"cloudstack_network_acl_rule.foo", "rule.1.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_network_acl_rule.foo", "rule.1.description", "Allow ICMP traffic"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_network_acl_rule.foo", "rule.2.description", "Allow HTTP and HTTPS"),
 				),
 			},
 
@@ -298,7 +308,6 @@ resource "cloudstack_network_acl_rule" "foo" {
   }
 
   rule {
-  	rule_number = 10
   	action = "deny"
 	cidr_list = ["172.18.100.0/24", "172.18.101.0/24"]
     protocol = "icmp"
@@ -309,7 +318,6 @@ resource "cloudstack_network_acl_rule" "foo" {
   }
 
   rule {
-	rule_number = 20
 	action = "allow"
     cidr_list = ["172.18.100.0/24"]
     protocol = "tcp"

--- a/cloudstack/resource_cloudstack_network_acl_rule_test.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule_test.go
@@ -245,19 +245,23 @@ resource "cloudstack_network_acl_rule" "foo" {
   acl_id = cloudstack_network_acl.foo.id
 
   rule {
+  	rule_number = 10
   	action = "allow"
     cidr_list = ["172.18.100.0/24"]
     protocol = "all"
     traffic_type = "ingress"
+	description = "Allow all traffic"
   }
 
   rule {
+  	rule_number = 20
   	action = "allow"
     cidr_list = ["172.18.100.0/24"]
     protocol = "icmp"
     icmp_type = "-1"
     icmp_code = "-1"
     traffic_type = "ingress"
+	description = "Allow ICMP traffic"
   }
 
   rule {
@@ -265,6 +269,7 @@ resource "cloudstack_network_acl_rule" "foo" {
     protocol = "tcp"
     ports = ["80", "443"]
     traffic_type = "ingress"
+	description = "Allow HTTP and HTTPS"
   }
 }`
 
@@ -293,16 +298,19 @@ resource "cloudstack_network_acl_rule" "foo" {
   }
 
   rule {
+  	rule_number = 10
   	action = "deny"
-		cidr_list = ["172.18.100.0/24", "172.18.101.0/24"]
+	cidr_list = ["172.18.100.0/24", "172.18.101.0/24"]
     protocol = "icmp"
     icmp_type = "-1"
     icmp_code = "-1"
     traffic_type = "ingress"
+	description = "Deny ICMP traffic"
   }
 
   rule {
-	  action = "allow"
+	rule_number = 20
+	action = "allow"
     cidr_list = ["172.18.100.0/24"]
     protocol = "tcp"
     ports = ["80", "443"]
@@ -310,10 +318,11 @@ resource "cloudstack_network_acl_rule" "foo" {
   }
 
   rule {
-	  action = "deny"
+	action = "deny"
     cidr_list = ["10.0.0.0/24"]
     protocol = "tcp"
     ports = ["80", "1000-2000"]
     traffic_type = "egress"
+	description = "Deny specific TCP ports"
   }
 }`

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 The `rule` block supports:
 
+* `rule_number` - (Optional) The number of the ACL item, its ordering.
+
 * `action` - (Optional) The action for the rule. Valid options are: `allow` and
     `deny` (defaults allow).
 
@@ -67,6 +69,8 @@ The `rule` block supports:
 
 * `traffic_type` - (Optional) The traffic type for the rule. Valid options are:
     `ingress` or `egress` (defaults ingress).
+
+* `description` - (Optional) A description indicating why the ACL rule is required.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This pr fixes:  https://github.com/apache/cloudstack-terraform-provider/issues/106


Tested with following:

```
terraform {
  required_providers {
    cloudstack = {
      source  = "local/cloudstack/cloudstack"
      version = "0.5.0"
    }
  }
}


provider "cloudstack" {}

/*
resource "cloudstack_instance" "web" {
  name             = "server-1"
  service_offering = "Small Instance"
  network_id       = "60f76fa9-d013-4f49-9bcb-a3815ff402a5"
  template         = "CentOS 5.5(64-bit) no GUI (KVM)"
  zone             = "ref-trl-9152-k-Mol9-manoj-kumar"
}
*/


resource "cloudstack_network_acl_rule" "default" {
  acl_id = "e0eb8b01-e03f-4951-96cf-844f1bebe9dc"

  rule {
    rule_number      = 30
    action       = "allow"
    cidr_list    = ["10.0.3.0/8"]
    protocol     = "tcp"
    ports        = ["3000"]
    traffic_type = "ingress"
    description  = "Some test desc new 30"
  }
}

resource "cloudstack_network_acl_rule" "test" {
  acl_id = "e0eb8b01-e03f-4951-96cf-844f1bebe9dc"

  rule {
    action       = "allow"
    cidr_list    = ["10.0.3.0/8"]
    protocol     = "tcp"
    ports        = ["3000"]
    traffic_type = "ingress"
    description  = "Some test"
  }
}

resource "cloudstack_network_acl_rule" "new" {
  acl_id = "e0eb8b01-e03f-4951-96cf-844f1bebe9dc"

  rule {
    rule_number      = 40
    action       = "allow"
    cidr_list    = ["10.0.3.0/8"]
    protocol     = "tcp"
    ports        = ["3000"]
    traffic_type = "ingress"
    description  = "Some test desc"
  }
}

resource "cloudstack_network_acl_rule" "conflict" {
  acl_id = "e0eb8b01-e03f-4951-96cf-844f1bebe9dc"

  rule {
    rule_number      = 40
    action       = "allow"
    cidr_list    = ["10.0.3.0/8"]
    protocol     = "tcp"
    ports        = ["3000"]
    traffic_type = "ingress"
    description  = "Some test desc"
  }
}