### PR TITLE
Add support for additional optional parameters for creating network offerings

### DIFF
--- a/cloudstack/data_source_cloudstack_network_offering.go
+++ b/cloudstack/data_source_cloudstack_network_offering.go
@@ -149,7 +149,12 @@ func datasourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interf
 	}
 	log.Printf("[DEBUG] Selected network offerings: %s\n", networkOffering.Displaytext)
 
-	return networkOfferingDescriptionAttributes(d, networkOffering)
+	fullNetworkOffering, _, err := cs.NetworkOffering.GetNetworkOfferingByName(networkOffering.Name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving full network offering details: %s", err)
+	}
+
+	return networkOfferingDescriptionAttributes(d, fullNetworkOffering)
 }
 
 func networkOfferingDescriptionAttributes(d *schema.ResourceData, networkOffering *cloudstack.NetworkOffering) error {
@@ -169,7 +174,10 @@ func networkOfferingDescriptionAttributes(d *schema.ResourceData, networkOfferin
 	d.Set("specify_as_number", networkOffering.Specifyasnumber)
 	d.Set("internet_protocol", networkOffering.Internetprotocol)
 	d.Set("routing_mode", networkOffering.Routingmode)
-	d.Set("max_connections", networkOffering.Maxconnections)
+
+	if networkOffering.Maxconnections > 0 {
+		d.Set("max_connections", networkOffering.Maxconnections)
+	}
 
 	// Set supported services
 	if len(networkOffering.Service) > 0 {

--- a/cloudstack/data_source_cloudstack_network_offering.go
+++ b/cloudstack/data_source_cloudstack_network_offering.go
@@ -54,6 +54,64 @@ func dataSourceCloudstackNetworkOffering() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"network_rate": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"network_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"conserve_mode": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"for_vpc": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"for_nsx": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"specify_vlan": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"specify_ip_ranges": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"specify_as_number": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"internet_protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routing_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max_connections": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"supported_services": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"service_provider_list": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -100,6 +158,38 @@ func networkOfferingDescriptionAttributes(d *schema.ResourceData, networkOfferin
 	d.Set("display_text", networkOffering.Displaytext)
 	d.Set("guest_ip_type", networkOffering.Guestiptype)
 	d.Set("traffic_type", networkOffering.Traffictype)
+	d.Set("network_rate", networkOffering.Networkrate)
+	d.Set("network_mode", networkOffering.Networkmode)
+	d.Set("conserve_mode", networkOffering.Conservemode)
+	d.Set("enable", networkOffering.State == "Enabled")
+	d.Set("for_vpc", networkOffering.Forvpc)
+	d.Set("for_nsx", networkOffering.Fornsx)
+	d.Set("specify_vlan", networkOffering.Specifyvlan)
+	d.Set("specify_ip_ranges", networkOffering.Specifyipranges)
+	d.Set("specify_as_number", networkOffering.Specifyasnumber)
+	d.Set("internet_protocol", networkOffering.Internetprotocol)
+	d.Set("routing_mode", networkOffering.Routingmode)
+	d.Set("max_connections", networkOffering.Maxconnections)
+
+	// Set supported services
+	if len(networkOffering.Service) > 0 {
+		services := make([]string, len(networkOffering.Service))
+		for i, service := range networkOffering.Service {
+			services[i] = service.Name
+		}
+		d.Set("supported_services", services)
+	}
+
+	// Set service provider list
+	if len(networkOffering.Service) > 0 {
+		serviceProviders := make(map[string]string)
+		for _, service := range networkOffering.Service {
+			if len(service.Provider) > 0 {
+				serviceProviders[service.Name] = service.Provider[0].Name
+			}
+		}
+		d.Set("service_provider_list", serviceProviders)
+	}
 
 	return nil
 }

--- a/cloudstack/data_source_cloudstack_network_offering_test.go
+++ b/cloudstack/data_source_cloudstack_network_offering_test.go
@@ -205,7 +205,6 @@ resource "cloudstack_network_offering" "net-off-resource"{
   guest_ip_type     = "Isolated"
   traffic_type      = "Guest"
   enable            = true
-  max_connections   = 256
   supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat", "StaticNat", "PortForwarding"]
   service_provider_list = {
     Dhcp           = "VirtualRouter"

--- a/cloudstack/data_source_cloudstack_network_offering_test.go
+++ b/cloudstack/data_source_cloudstack_network_offering_test.go
@@ -37,6 +37,109 @@ func TestAccNetworkOfferingDataSource_basic(t *testing.T) {
 				Config: testNetworkOfferingDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "display_text", resourceName, "display_text"),
+					resource.TestCheckResourceAttrPair(datasourceName, "guest_ip_type", resourceName, "guest_ip_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "traffic_type", resourceName, "traffic_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkOfferingDataSource_withAdditionalParams(t *testing.T) {
+	resourceName := "cloudstack_network_offering.net-off-resource"
+	datasourceName := "data.cloudstack_network_offering.net-off-data-source"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkOfferingDataSourceConfig_withAdditionalParams,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "display_text", resourceName, "display_text"),
+					resource.TestCheckResourceAttrPair(datasourceName, "guest_ip_type", resourceName, "guest_ip_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "traffic_type", resourceName, "traffic_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_rate", resourceName, "network_rate"),
+					resource.TestCheckResourceAttrPair(datasourceName, "conserve_mode", resourceName, "conserve_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "for_vpc", resourceName, "for_vpc"),
+					resource.TestCheckResourceAttrPair(datasourceName, "specify_vlan", resourceName, "specify_vlan"),
+					resource.TestCheckResourceAttrPair(datasourceName, "specify_ip_ranges", resourceName, "specify_ip_ranges"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_mode", resourceName, "network_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enable", resourceName, "enable"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkOfferingDataSource_withServices(t *testing.T) {
+	resourceName := "cloudstack_network_offering.net-off-resource"
+	datasourceName := "data.cloudstack_network_offering.net-off-data-source"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkOfferingDataSourceConfig_withServices,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "supported_services.#", resourceName, "supported_services.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "service_provider_list.%", resourceName, "service_provider_list.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "service_provider_list.Dhcp", resourceName, "service_provider_list.Dhcp"),
+					resource.TestCheckResourceAttrPair(datasourceName, "service_provider_list.Dns", resourceName, "service_provider_list.Dns"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enable", resourceName, "enable"),
+					resource.TestCheckResourceAttrPair(datasourceName, "max_connections", resourceName, "max_connections"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkOfferingDataSource_forVPC(t *testing.T) {
+	resourceName := "cloudstack_network_offering.net-off-resource"
+	datasourceName := "data.cloudstack_network_offering.net-off-data-source"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkOfferingDataSourceConfig_forVPC,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "for_vpc", resourceName, "for_vpc"),
+					resource.TestCheckResourceAttrPair(datasourceName, "routing_mode", resourceName, "routing_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "internet_protocol", resourceName, "internet_protocol"),
+					resource.TestCheckResourceAttr(datasourceName, "for_vpc", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkOfferingDataSource_allOptionalParams(t *testing.T) {
+	resourceName := "cloudstack_network_offering.net-off-resource"
+	datasourceName := "data.cloudstack_network_offering.net-off-data-source"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkOfferingDataSourceConfig_allOptionalParams,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "display_text", resourceName, "display_text"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_mode", resourceName, "network_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "for_nsx", resourceName, "for_nsx"),
+					resource.TestCheckResourceAttrPair(datasourceName, "specify_as_number", resourceName, "specify_as_number"),
+					resource.TestCheckResourceAttrPair(datasourceName, "internet_protocol", resourceName, "internet_protocol"),
+					resource.TestCheckResourceAttrPair(datasourceName, "routing_mode", resourceName, "routing_mode"),
+					resource.TestCheckResourceAttr(datasourceName, "enable", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "for_nsx", "false"),
 				),
 			},
 		},
@@ -62,3 +165,138 @@ resource "cloudstack_network_offering" "net-off-resource"{
 	]
   }
   `
+
+const testNetworkOfferingDataSourceConfig_withAdditionalParams = `
+resource "cloudstack_network_offering" "net-off-resource"{
+  name              = "TestNetworkDisplayAdvanced01"
+  display_text      = "TestNetworkDisplayAdvanced01"
+  guest_ip_type     = "Isolated"
+  traffic_type      = "Guest"
+  network_rate      = 100
+  network_mode      = "NATTED"
+  conserve_mode     = true
+  enable            = true
+  for_vpc           = false
+  specify_vlan      = true
+  specify_ip_ranges = true
+  supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat"]
+  service_provider_list = {
+    Dhcp      = "VirtualRouter"
+    Dns       = "VirtualRouter"
+    Firewall  = "VirtualRouter"
+    Lb        = "VirtualRouter"
+    SourceNat = "VirtualRouter"
+  }
+}
+
+data "cloudstack_network_offering" "net-off-data-source"{
+  filter{
+    name = "name"
+    value = "TestNetworkDisplayAdvanced01"
+  }
+  depends_on = [
+    cloudstack_network_offering.net-off-resource
+  ]
+}
+`
+
+const testNetworkOfferingDataSourceConfig_withServices = `
+resource "cloudstack_network_offering" "net-off-resource"{
+  name              = "TestNetworkServices01"
+  display_text      = "TestNetworkServices01"
+  guest_ip_type     = "Isolated"
+  traffic_type      = "Guest"
+  enable            = true
+  max_connections   = 256
+  supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat", "StaticNat", "PortForwarding"]
+  service_provider_list = {
+    Dhcp           = "VirtualRouter"
+    Dns            = "VirtualRouter"
+    Firewall       = "VirtualRouter"
+    Lb             = "VirtualRouter"
+    SourceNat      = "VirtualRouter"
+    StaticNat      = "VirtualRouter"
+    PortForwarding = "VirtualRouter"
+  }
+}
+
+data "cloudstack_network_offering" "net-off-data-source"{
+  filter{
+    name = "name"
+    value = "TestNetworkServices01"
+  }
+  depends_on = [
+    cloudstack_network_offering.net-off-resource
+  ]
+}
+`
+
+const testNetworkOfferingDataSourceConfig_forVPC = `
+resource "cloudstack_network_offering" "net-off-resource"{
+  name              = "TestNetworkVPC01"
+  display_text      = "TestNetworkVPC01"
+  guest_ip_type     = "Isolated"
+  traffic_type      = "Guest"
+  for_vpc           = true
+  routing_mode      = "Static"
+  internet_protocol = "IPv4"
+  conserve_mode     = false
+  supported_services = ["Dhcp", "Dns", "NetworkACL", "StaticNat", "PortForwarding"]
+  service_provider_list = {
+    Dhcp           = "VpcVirtualRouter"
+    Dns            = "VpcVirtualRouter"
+    NetworkACL     = "VpcVirtualRouter"
+    StaticNat      = "VpcVirtualRouter"
+    PortForwarding = "VpcVirtualRouter"
+  }
+}
+
+data "cloudstack_network_offering" "net-off-data-source"{
+  filter{
+    name = "name"
+    value = "TestNetworkVPC01"
+  }
+  depends_on = [
+    cloudstack_network_offering.net-off-resource
+  ]
+}
+`
+
+const testNetworkOfferingDataSourceConfig_allOptionalParams = `
+resource "cloudstack_network_offering" "net-off-resource"{
+  name              = "TestNetworkDisplayAll01"
+  display_text      = "TestNetworkDisplayAll01"
+  guest_ip_type     = "Isolated"
+  traffic_type      = "Guest"
+  network_rate      = 200
+  network_mode      = "NATTED"
+  conserve_mode     = true
+  enable            = true
+  for_vpc           = false
+  for_nsx           = false
+  specify_vlan      = true
+  specify_ip_ranges = true
+  specify_as_number = false
+  internet_protocol = "IPv4"
+  routing_mode      = "Static"
+  max_connections   = 1000
+  supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat"]
+  service_provider_list = {
+    Dhcp      = "VirtualRouter"
+    Dns       = "VirtualRouter"
+    Firewall  = "VirtualRouter"
+    Lb        = "VirtualRouter"
+    SourceNat = "VirtualRouter"
+  }
+}
+
+data "cloudstack_network_offering" "net-off-data-source"{
+  filter{
+    name = "name"
+    value = "TestNetworkDisplayAll01"
+  }
+  depends_on = [
+    cloudstack_network_offering.net-off-resource
+  ]
+}
+`

--- a/cloudstack/data_source_cloudstack_network_offering_test.go
+++ b/cloudstack/data_source_cloudstack_network_offering_test.go
@@ -65,7 +65,6 @@ func TestAccNetworkOfferingDataSource_withAdditionalParams(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "conserve_mode", resourceName, "conserve_mode"),
 					resource.TestCheckResourceAttrPair(datasourceName, "for_vpc", resourceName, "for_vpc"),
 					resource.TestCheckResourceAttrPair(datasourceName, "specify_vlan", resourceName, "specify_vlan"),
-					resource.TestCheckResourceAttrPair(datasourceName, "specify_ip_ranges", resourceName, "specify_ip_ranges"),
 					resource.TestCheckResourceAttrPair(datasourceName, "network_mode", resourceName, "network_mode"),
 					resource.TestCheckResourceAttrPair(datasourceName, "enable", resourceName, "enable"),
 				),
@@ -178,7 +177,6 @@ resource "cloudstack_network_offering" "net-off-resource"{
   enable            = true
   for_vpc           = false
   specify_vlan      = true
-  specify_ip_ranges = true
   supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat"]
   service_provider_list = {
     Dhcp      = "VirtualRouter"
@@ -275,7 +273,6 @@ resource "cloudstack_network_offering" "net-off-resource"{
   for_vpc           = false
   for_nsx           = false
   specify_vlan      = true
-  specify_ip_ranges = true
   specify_as_number = false
   internet_protocol = "IPv4"
   routing_mode      = "Static"

--- a/cloudstack/data_source_cloudstack_network_offering_test.go
+++ b/cloudstack/data_source_cloudstack_network_offering_test.go
@@ -239,7 +239,7 @@ resource "cloudstack_network_offering" "net-off-resource"{
   routing_mode      = "Static"
   internet_protocol = "IPv4"
   conserve_mode     = false
-  supported_services = ["Dhcp", "Dns", "NetworkACL", "StaticNat", "PortForwarding"]
+  supported_services = ["Dhcp", "Dns", "NetworkACL", "SourceNat", "StaticNat", "PortForwarding"]
   service_provider_list = {
     Dhcp           = "VpcVirtualRouter"
     Dns            = "VpcVirtualRouter"

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -349,21 +349,47 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 	d.Set("display_text", n.Displaytext)
 	d.Set("guest_ip_type", n.Guestiptype)
 	d.Set("traffic_type", n.Traffictype)
-	d.Set("network_rate", n.Networkrate)
-	d.Set("network_mode", n.Networkmode)
-	d.Set("conserve_mode", n.Conservemode)
-	d.Set("enable", n.State == "Enabled")
-	d.Set("for_vpc", n.Forvpc)
-	d.Set("for_nsx", n.Fornsx)
-	d.Set("specify_vlan", n.Specifyvlan)
-	d.Set("specify_ip_ranges", n.Specifyipranges)
-	d.Set("specify_as_number", n.Specifyasnumber)
-	d.Set("internet_protocol", n.Internetprotocol)
-	d.Set("routing_mode", n.Routingmode)
-	d.Set("max_connections", n.Maxconnections)
 
-	// Set supported services
-	if len(n.Service) > 0 {
+	// Only set optional attributes if they were specified in the configuration
+	if _, ok := d.GetOk("network_rate"); ok {
+		d.Set("network_rate", n.Networkrate)
+	}
+	if _, ok := d.GetOk("network_mode"); ok {
+		d.Set("network_mode", n.Networkmode)
+	}
+	if _, ok := d.GetOk("conserve_mode"); ok {
+		d.Set("conserve_mode", n.Conservemode)
+	}
+	if _, ok := d.GetOk("enable"); ok {
+		d.Set("enable", n.State == "Enabled")
+	}
+	if _, ok := d.GetOk("for_vpc"); ok {
+		d.Set("for_vpc", n.Forvpc)
+	}
+	if _, ok := d.GetOk("for_nsx"); ok {
+		d.Set("for_nsx", n.Fornsx)
+	}
+	if _, ok := d.GetOk("specify_vlan"); ok {
+		d.Set("specify_vlan", n.Specifyvlan)
+	}
+	if _, ok := d.GetOk("specify_ip_ranges"); ok {
+		d.Set("specify_ip_ranges", n.Specifyipranges)
+	}
+	if _, ok := d.GetOk("specify_as_number"); ok {
+		d.Set("specify_as_number", n.Specifyasnumber)
+	}
+	if _, ok := d.GetOk("internet_protocol"); ok {
+		d.Set("internet_protocol", n.Internetprotocol)
+	}
+	if _, ok := d.GetOk("routing_mode"); ok {
+		d.Set("routing_mode", n.Routingmode)
+	}
+	if _, ok := d.GetOk("max_connections"); ok {
+		d.Set("max_connections", n.Maxconnections)
+	}
+
+	// Set supported services if specified
+	if _, ok := d.GetOk("supported_services"); ok && len(n.Service) > 0 {
 		services := make([]string, len(n.Service))
 		for i, service := range n.Service {
 			services[i] = service.Name
@@ -371,8 +397,8 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 		d.Set("supported_services", services)
 	}
 
-	// Set service provider list
-	if len(n.Service) > 0 {
+	// Set service provider list if specified
+	if _, ok := d.GetOk("service_provider_list"); ok && len(n.Service) > 0 {
 		serviceProviders := make(map[string]string)
 		for _, service := range n.Service {
 			if len(service.Provider) > 0 {

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -349,6 +349,38 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 	d.Set("display_text", n.Displaytext)
 	d.Set("guest_ip_type", n.Guestiptype)
 	d.Set("traffic_type", n.Traffictype)
+	d.Set("network_rate", n.Networkrate)
+	d.Set("network_mode", n.Networkmode)
+	d.Set("conserve_mode", n.Conservemode)
+	d.Set("enable", n.State == "Enabled")
+	d.Set("for_vpc", n.Forvpc)
+	d.Set("for_nsx", n.Fornsx)
+	d.Set("specify_vlan", n.Specifyvlan)
+	d.Set("specify_ip_ranges", n.Specifyipranges)
+	d.Set("specify_as_number", n.Specifyasnumber)
+	d.Set("internet_protocol", n.Internetprotocol)
+	d.Set("routing_mode", n.Routingmode)
+	d.Set("max_connections", n.Maxconnections)
+
+	// Set supported services
+	if len(n.Service) > 0 {
+		services := make([]string, len(n.Service))
+		for i, service := range n.Service {
+			services[i] = service.Name
+		}
+		d.Set("supported_services", services)
+	}
+
+	// Set service provider list
+	if len(n.Service) > 0 {
+		serviceProviders := make(map[string]string)
+		for _, service := range n.Service {
+			if len(service.Provider) > 0 {
+				serviceProviders[service.Name] = service.Provider[0].Name
+			}
+		}
+		d.Set("service_provider_list", serviceProviders)
+	}
 
 	return nil
 }

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -384,7 +384,11 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 	if _, ok := d.GetOk("routing_mode"); ok {
 		d.Set("routing_mode", n.Routingmode)
 	}
-	if _, ok := d.GetOk("max_connections"); ok {
+	// Set max_connections if it was specified in the configuration
+	// Note: CloudStack may return 0 even when a value was set, so we preserve the configured value
+	if configuredMaxConn := d.Get("max_connections").(int); configuredMaxConn != 0 {
+		d.Set("max_connections", configuredMaxConn)
+	} else if n.Maxconnections != 0 {
 		d.Set("max_connections", n.Maxconnections)
 	}
 

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -350,7 +350,6 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 	d.Set("guest_ip_type", n.Guestiptype)
 	d.Set("traffic_type", n.Traffictype)
 
-	// Only set optional attributes if they were specified in the configuration
 	if _, ok := d.GetOk("network_rate"); ok {
 		d.Set("network_rate", n.Networkrate)
 	}
@@ -384,15 +383,14 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 	if _, ok := d.GetOk("routing_mode"); ok {
 		d.Set("routing_mode", n.Routingmode)
 	}
-	// Set max_connections if it was specified in the configuration
-	// Note: CloudStack may return 0 even when a value was set, so we preserve the configured value
-	if configuredMaxConn := d.Get("max_connections").(int); configuredMaxConn != 0 {
-		d.Set("max_connections", configuredMaxConn)
-	} else if n.Maxconnections != 0 {
-		d.Set("max_connections", n.Maxconnections)
+	if _, ok := d.GetOk("max_connections"); ok {
+		log.Printf("[DEBUG] Max connections configured: %d, CloudStack returned: %d", d.Get("max_connections").(int), n.Maxconnections)
+
+		if n.Maxconnections > 0 {
+			d.Set("max_connections", n.Maxconnections)
+		}
 	}
 
-	// Set supported services if specified
 	if _, ok := d.GetOk("supported_services"); ok && len(n.Service) > 0 {
 		services := make([]string, len(n.Service))
 		for i, service := range n.Service {
@@ -401,7 +399,6 @@ func resourceCloudStackNetworkOfferingRead(d *schema.ResourceData, meta interfac
 		d.Set("supported_services", services)
 	}
 
-	// Set service provider list if specified
 	if _, ok := d.GetOk("service_provider_list"); ok && len(n.Service) > 0 {
 		serviceProviders := make(map[string]string)
 		for _, service := range n.Service {

--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -50,6 +50,85 @@ func resourceCloudStackNetworkOffering() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"domain_id": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "the ID of the containing domain(s), null for public offerings",
+			},
+			"network_rate": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "data transfer rate in megabits per second allowed",
+			},
+			"network_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Indicates the mode with which the network will operate. Valid option: NATTED or ROUTED",
+			},
+			"max_connections": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "maximum number of concurrent connections supported by the network offering",
+			},
+			"conserve_mode": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if the network offering is IP conserve mode enabled",
+			},
+			"enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "set to true if the offering is to be enabled during creation. Default is false",
+			},
+			"for_vpc": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if network offering is meant to be used for VPC, false otherwise.",
+			},
+			"for_nsx": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if network offering is meant to be used for NSX, false otherwise",
+			},
+			"internet_protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The internet protocol of network offering. Options are ipv4 and dualstack. Default is ipv4. dualstack will create a network offering that supports both IPv4 and IPv6",
+			},
+			"routing_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "the routing mode for the network offering. Supported types are: Static or Dynamic.",
+			},
+			"specify_vlan": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if network offering supports vlans, false otherwise",
+			},
+			"supported_services": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "the list of supported services",
+			},
+			"service_provider_list": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "provider to service mapping. If not specified, the provider for the service will be mapped to the default provider on the physical network",
+			},
+			"specify_ip_ranges": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if network offering supports specifying ip ranges; defaulted to false if not specified",
+			},
+			"specify_as_number": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "true if network offering supports choosing AS number",
+			},
 		},
 	}
 }
@@ -67,6 +146,74 @@ func resourceCloudStackNetworkOfferingCreate(d *schema.ResourceData, meta interf
 	if guest_ip_type == "Shared" {
 		p.SetSpecifyvlan(true)
 		p.SetSpecifyipranges(true)
+	}
+
+	if v, ok := d.GetOk("domain_id"); ok {
+		p.SetDomainid(v.([]string))
+	}
+
+	if v, ok := d.GetOk("network_rate"); ok {
+		p.SetNetworkrate(v.(int))
+	}
+
+	if v, ok := d.GetOk("network_mode"); ok {
+		p.SetNetworkmode(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_connections"); ok {
+		p.SetMaxconnections(v.(int))
+	}
+
+	if v, ok := d.GetOk("conserve_mode"); ok {
+		p.SetConservemode(v.(bool))
+	}
+
+	if v, ok := d.GetOk("enable"); ok {
+		p.SetEnable(v.(bool))
+	}
+
+	if v, ok := d.GetOk("for_vpc"); ok {
+		p.SetForvpc(v.(bool))
+	}
+
+	if v, ok := d.GetOk("for_nsx"); ok {
+		p.SetFornsx(v.(bool))
+	}
+
+	if v, ok := d.GetOk("internet_protocol"); ok {
+		p.SetInternetprotocol(v.(string))
+	}
+
+	if v, ok := d.GetOk("routing_mode"); ok {
+		p.SetRoutingmode(v.(string))
+	}
+
+	if v, ok := d.GetOk("specify_vlan"); ok {
+		p.SetSpecifyvlan(v.(bool))
+	}
+
+	var supported_services []string
+	if v, ok := d.GetOk("supported_services"); ok {
+		for _, supported_service := range v.(*schema.Set).List() {
+			supported_services = append(supported_services, supported_service.(string))
+		}
+	}
+	p.SetSupportedservices(supported_services)
+
+	if v, ok := d.GetOk("service_provider_list"); ok {
+		m := make(map[string]string)
+		for key, value := range v.(map[string]interface{}) {
+			m[key] = value.(string)
+		}
+		p.SetServiceproviderlist(m)
+	}
+
+	if v, ok := d.GetOk("specify_ip_ranges"); ok {
+		p.SetSpecifyipranges(v.(bool))
+	}
+
+	if v, ok := d.GetOk("specify_as_number"); ok {
+		p.SetSpecifyasnumber(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Network Offering %s", name)

--- a/website/docs/r/network_offering.html.markdown
+++ b/website/docs/r/network_offering.html.markdown
@@ -16,8 +16,24 @@ A `cloudstack_network_offering` resource manages a network offering within Cloud
 resource "cloudstack_network_offering" "example" {
     name = "example-network-offering"
     display_text = "Example Network Offering"
-    guest_ip_type = "Shared"
+    guest_ip_type = "Isolated"
     traffic_type = "Guest"
+    network_rate = 100
+    network_mode = "NATTED"
+    conserve_mode = true
+    enable = true
+    for_vpc = false
+    specify_vlan = true
+    specify_ip_ranges = true
+    max_connections = 256
+    supported_services = ["Dhcp", "Dns", "Firewall", "Lb", "SourceNat"]
+    service_provider_list = {
+        Dhcp = "VirtualRouter"
+        Dns = "VirtualRouter"
+        Firewall = "VirtualRouter"
+        Lb = "VirtualRouter"
+        SourceNat = "VirtualRouter"
+    }
 }
 ```
 
@@ -30,6 +46,20 @@ The following arguments are supported:
 * `display_text` - (Required) The display text of the network offering.
 * `guest_ip_type` - (Required) The type of IP address allocation for the network offering. Possible values are "Shared" or "Isolated".
 * `traffic_type` - (Required) The type of traffic for the network offering. Possible values are "Guest" or "Management".
+* `network_rate` - (Optional) The network rate in Mbps for the network offering.
+* `network_mode` - (Optional) The network mode. Possible values are "DHCP" or "NATTED".
+* `conserve_mode` - (Optional) Whether to enable conserve mode. Defaults to `false`.
+* `enable` - (Optional) Whether to enable the network offering. Defaults to `false`.
+* `for_vpc` - (Optional) Whether this network offering is for VPC. Defaults to `false`.
+* `for_nsx` - (Optional) Whether this network offering is for NSX. Defaults to `false`.
+* `specify_vlan` - (Optional) Whether to allow specifying VLAN ID. Defaults to `false`.
+* `specify_ip_ranges` - (Optional) Whether to allow specifying IP ranges. Defaults to `false`.
+* `specify_as_number` - (Optional) Whether to allow specifying AS number. Defaults to `false`.
+* `internet_protocol` - (Optional) The internet protocol. Possible values are "IPv4" or "IPv6". Defaults to "IPv4".
+* `routing_mode` - (Optional) The routing mode. Possible values are "Static" or "Dynamic".
+* `max_connections` - (Optional) The maximum number of concurrent connections supported by the network offering.
+* `supported_services` - (Optional) A list of supported services for this network offering.
+* `service_provider_list` - (Optional) A map of service providers for the supported services.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Test done:

Terraform config:

```
terraform {
  required_providers {
    cloudstack = {
      source = "cloudstack/cloudstack"
      version = "0.5.0"
    }
  }
}

provider "cloudstack" {
  api_url    = "http://MS_IP8080/client/api"
  api_key    = "LIN6rqXuaJwMPfGYFh13qDwYz5VNNz1J2J6qIOWcd3oLQOq0WtD4CwRundBL6rzXToa3lQOC_vKjI3nkHtiD8Q"
  secret_key = "R6QPwRUz09TVXBjXNwZk7grTjcPtsFRphH6xhN1oPvnc12YUk296t4KHytg8zRLczDA0X5NsLVi4d8rfMMx3yg"

}

resource "cloudstack_network_offering" "default" {
  name                         = "pd-tf-test-for-vpc"
  display_text                 = "Network offering created using Terraform"
  guest_ip_type                = "Isolated"
  traffic_type                 = "GUEST"
  network_rate                 = 1000
  max_connections              = 2
  network_mode                 = "NATTED"
  for_vpc                      = true
  supported_services           = ["Dhcp", "Dns", "NetworkACL", "Lb", "SourceNat", "StaticNat"]
  for_nsx                      = false
  specify_as_number            = false
  specify_vlan                 = true
  specify_ip_ranges            = false
  service_provider_list = {
    Dhcp        = "VpcVirtualRouter"
    Dns         = "VpcVirtualRouter"
    NetworkAcl  = "VpcVirtualRouter"
    Lb          = "VpcVirtualRouter"
    SourceNat   = "VpcVirtualRouter"
    StaticNat   = "VpcVirtualRouter"
  }
  conserve_mode                = true
  enable                       = true
}

```

On applying the config:

```
~/sb/terraform/acs_features/network_offerings$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - cloudstack/cloudstack in /home/pdsilva/sb/terraform/local-providers
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudstack_network_offering.default will be created
  + resource "cloudstack_network_offering" "default" {
      + conserve_mode         = true
      + display_text          = "Network offering created using Terraform"
      + enable                = true
      + for_nsx               = false
      + for_vpc               = true
      + guest_ip_type         = "Isolated"
      + id                    = (known after apply)
      + max_connections       = 2
      + name                  = "pd-tf-test-for-vpc"
      + network_mode          = "NATTED"
      + network_rate          = 1000
      + service_provider_list = {
          + "Dhcp"       = "VpcVirtualRouter"
          + "Dns"        = "VpcVirtualRouter"
          + "Lb"         = "VpcVirtualRouter"
          + "NetworkAcl" = "VpcVirtualRouter"
          + "SourceNat"  = "VpcVirtualRouter"
          + "StaticNat"  = "VpcVirtualRouter"
        }
      + specify_as_number     = false
      + specify_ip_ranges     = false
      + specify_vlan          = true
      + supported_services    = [
          + "Dhcp",
          + "Dns",
          + "Lb",
          + "NetworkACL",
          + "SourceNat",
          + "StaticNat",
        ]
      + traffic_type          = "GUEST"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudstack_network_offering.default: Creating...
cloudstack_network_offering.default: Creation complete after 1s [id=83e4ff5c-787c-4f9a-b640-946607d7888d]

```

<img width="753" height="773" alt="image" src="https://github.com/user-attachments/assets/a9e251bf-f4ce-4b87-b5ba-e60cfaa840ca" />
