### PR TITLE
data: get vpc in project by projectid

### DIFF
--- a/cloudstack/data_source_cloudstack_vpc.go
+++ b/cloudstack/data_source_cloudstack_vpc.go
@@ -37,6 +37,11 @@ func dataSourceCloudstackVPC() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"filter": dataSourceFiltersSchema(),
 
+			"projectid": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			//Computed values
 			"name": {
 				Type:     schema.TypeString,
@@ -81,6 +86,9 @@ func dataSourceCloudstackVPC() *schema.Resource {
 func datasourceCloudStackVPCRead(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	p := cs.VPC.NewListVPCsParams()
+	if d.Get("projectid") != "" {
+		p.SetProjectid(d.Get("projectid").(string))
+	}
 	csVPCs, err := cs.VPC.ListVPCs(p)
 
 	if err != nil {


### PR DESCRIPTION
This fixes #162 

- Create a vpc in project

```
# cat new-vpc-project.tf
resource "cloudstack_vpc" "new-project-vpc" {
  project = "project-001"
  name = "project-vpc2"
  cidr = "172.17.0.0/20"
  vpc_offering = "Default VPC offering"
  zone         = "ref-trl-8888-k-Mol8-wei-zhou"
}

# terraform apply 
cloudstack_vpc.new-project-vpc: Refreshing state... [id=aeb4cfa1-2696-4d87-aa06-335dd83a471a]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudstack_vpc.new-project-vpc will be created
  + resource "cloudstack_vpc" "new-project-vpc" {
      + cidr           = "172.17.0.0/20"
      + display_text   = (known after apply)
      + id             = (known after apply)
      + name           = "project-vpc2"
      + network_domain = (known after apply)
      + project        = "project-001"
      + source_nat_ip  = (known after apply)
      + tags           = (known after apply)
      + vpc_offering   = "Default VPC offering"
      + zone           = "ref-trl-8888-k-Mol8-wei-zhou"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudstack_vpc.new-project-vpc: Creating...
cloudstack_vpc.new-project-vpc: Still creating... [00m10s elapsed]
cloudstack_vpc.new-project-vpc: Still creating... [00m20s elapsed]
cloudstack_vpc.new-project-vpc: Still creating... [00m30s elapsed]
cloudstack_vpc.new-project-vpc: Still creating... [00m40s elapsed]
cloudstack_vpc.new-project-vpc: Still creating... [00m50s elapsed]
cloudstack_vpc.new-project-vpc: Creation complete after 56s [id=aeb4cfa1-2696-4d87-aa06-335dd83a471a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```



- get vpc in project
```
# cat vpc-project.tf 
data "cloudstack_vpc" "project-vpc2" {
  projectid = "07e3217f-bc85-4ab6-9be9-98ea43038165"
  filter{
    name  = "cidr"
    value = "172.17.0.0/20"
  }
  filter{
    name  = "name"
    value = "project-vpc2"
  }
}

# terraform apply 
data.cloudstack_vpc.project-vpc2: Reading...
cloudstack_vpc.new-project-vpc: Refreshing state... [id=aeb4cfa1-2696-4d87-aa06-335dd83a471a]
data.cloudstack_vpc.project-vpc2: Read complete after 0s [id=aeb4cfa1-2696-4d87-aa06-335dd83a471a]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```