### PR TITLE
serviceoffering: add params for custom offering, storage tags, encryptroot

### DIFF
--- a/cloudstack/resource_cloudstack_service_offering.go
+++ b/cloudstack/resource_cloudstack_service_offering.go
@@ -365,14 +365,14 @@ func resourceCloudStackServiceOfferingUpdate(d *schema.ResourceData, meta interf
 
 	}
 
-	if d.HasChange("tags") {
+	if d.HasChange("storage_tags") {
 		log.Printf("[DEBUG] Tags changed for %s, starting update", name)
 
 		// Create a new parameter struct
 		p := cs.ServiceOffering.NewUpdateServiceOfferingParams(d.Id())
 
 		// Set the new tags
-		p.SetStoragetags(d.Get("tags").(string))
+		p.SetStoragetags(d.Get("storage_tags").(string))
 
 		// Update the host tags
 		_, err := cs.ServiceOffering.UpdateServiceOffering(p)

--- a/cloudstack/resource_cloudstack_service_offering.go
+++ b/cloudstack/resource_cloudstack_service_offering.go
@@ -139,7 +139,6 @@ func resourceCloudStackServiceOffering() *schema.Resource {
 				Description: "Storage tags to associate with the service offering",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 			},
 		},
 	}

--- a/cloudstack/resource_cloudstack_service_offering_test.go
+++ b/cloudstack/resource_cloudstack_service_offering_test.go
@@ -83,3 +83,42 @@ func testAccCheckCloudStackServiceOfferingExists(n string, so *cloudstack.Servic
 		return nil
 	}
 }
+
+func TestAccCloudStackServiceOffering_customized(t *testing.T) {
+	var so cloudstack.ServiceOffering
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackServiceOffering_customized,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackServiceOfferingExists("cloudstack_service_offering.custom", &so),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "customized", "true"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "min_cpu_number", "1"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "max_cpu_number", "8"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "min_memory", "1024"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "max_memory", "16384"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "cpu_speed", "1000"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "encrypt_root", "true"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering.custom", "storage_tags", "production,ssd"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackServiceOffering_customized = `
+resource "cloudstack_service_offering" "custom" {
+  name             = "custom_service_offering"
+  display_text     = "Custom Test"
+  customized       = true
+  min_cpu_number   = 1
+  max_cpu_number   = 8
+  min_memory       = 1024
+  max_memory       = 16384
+  cpu_speed        = 1000
+  encrypt_root     = true
+  storage_tags     = "production,ssd"
+}
+`

--- a/website/docs/r/service_offering.html.markdown
+++ b/website/docs/r/service_offering.html.markdown
@@ -49,6 +49,26 @@ The following arguments are supported:
 * `storage_type` - (Optional) The storage type of the service offering. Values are `local` and `shared`.
     Changing this forces a new resource to be created.
 
+* `customized` - (Optional) Whether the service offering allows custom CPU and memory values. Set to `true` to enable users to specify CPU/memory within the min/max constraints for constrained offerings and any value for unconstrained offerings.
+    Changing this forces a new resource to be created.
+
+* `min_cpu_number` - (Optional) Minimum number of CPU cores allowed for customized offerings.
+    Changing this forces a new resource to be created.
+
+* `max_cpu_number` - (Optional) Maximum number of CPU cores allowed for customized offerings.
+    Changing this forces a new resource to be created.
+
+* `min_memory` - (Optional) Minimum memory (in MB) allowed for customized offerings.
+    Changing this forces a new resource to be created.
+
+* `max_memory` - (Optional) Maximum memory (in MB) allowed for customized offerings.
+    Changing this forces a new resource to be created.
+
+* `encrypt_root` - (Optional) Whether to encrypt the root disk for VMs using this service offering.
+    Changing this forces a new resource to be created.
+
+* `storage_tags` - (Optional) Storage tags to associate with the service offering.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Fixes #182 

Adds params for Custom offerings. Constrained custom offerings allow min/max values for CPU and memory. Also adds params for encrypt root and storage tags.

New params added,
- customized
- min_cpu_number
- max_cpu_number
- min_memory
- max_memory
- encrypt_root
- storage_tags