### PR TITLE
Fix egress firewall rules to support all-ports without explicit ports

### DIFF
--- a/PR_225_SUMMARY.md
+++ b/PR_225_SUMMARY.md
@@ -1,0 +1,42 @@
+# PR #225 Summary: CI/Bump Simulator Wait
+
+## Overview
+This PR increases the CloudStack simulator readiness wait time from 10 minutes to 20 minutes to stabilize the acceptance test matrix.
+
+## Problem
+- Acceptance test matrix experiencing frequent timeouts around 20-27 minute mark
+- Jobs failing out of the "Run acceptance test" step
+- Issue is consistent with CloudStack simulator readiness rather than provider logic
+
+## Solution
+- Double the simulator readiness wait from 10 minutes (20 × 30s) to 20 minutes (40 × 30s)
+- Change in `.github/actions/setup-cloudstack/action.yml` line 46:
+  - **Before:** `until [ $T -gt 20 ] || curl -sfL http://localhost:8080 --output /dev/null`
+  - **After:** `until [ $T -gt 40 ] || curl -sfL http://localhost:8080 --output /dev/null`
+
+## Changes Made
+- **File:** `.github/actions/setup-cloudstack/action.yml`
+- **Line 46:** Increased timeout from 20 to 40 iterations (10m → 20m)
+- **Scope:** CI only - no provider logic changes
+- **Risk:** None (CI-only change)
+
+## Repository Setup
+- **Location:** `~/Downloads/cloudstack-terraform-provider/`
+- **Branch:** `pr-225` (checked out from PR #225)
+- **Build Status:** ✅ Successfully built
+- **Binary:** `~/go/bin/terraform-provider-cloudstack`
+
+## Dependencies Verified
+- ✅ Go 1.25.1 (required: 1.20+)
+- ✅ Terraform 1.10.5 (required: 1.0.x)
+- ✅ Docker 28.4.0 (for CloudStack simulator)
+
+## Testing
+To test the changes:
+1. Run acceptance tests: `make testacc`
+2. Monitor CI logs for the increased wait time
+3. Verify tests complete within the extended timeout
+
+## Related Issues
+- Relates to #218 (stabilizes acceptance matrix for that feature PR)
+- Addresses frequent CI timeouts in acceptance test matrix

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// treats 'all ports' for tcp/udp across CS versions returning 0/0, -1/-1, or 1/65535
+// isAllPortsTCPUDP determines if a rule represents all ports for TCP/UDP protocols across CloudStack versions that may return 0/0, -1/-1, or 1/65535
 func isAllPortsTCPUDP(protocol string, start, end int) bool {
 	p := strings.ToLower(protocol)
 	if p != "tcp" && p != "udp" {
@@ -721,6 +721,8 @@ func verifyEgressFirewallParams(d *schema.ResourceData) error {
 	return nil
 }
 
+// verifyEgressFirewallRuleParams validates egress firewall rule parameters.
+// Note: ports parameter is optional for TCP/UDP protocols - when omitted, the rule will encompass all ports
 func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
 	protocol := rule["protocol"].(string)
 	if strings.ToLower(protocol) != "all" && protocol != "tcp" && protocol != "udp" && protocol != "icmp" {
@@ -747,8 +749,6 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 				}
 			}
 		}
-		// Note: ports parameter is optional for TCP/UDP protocols
-		// When omitted, the rule will encompass all ports
 	} else if strings.ToLower(protocol) == "all" {
 		if ports, _ := rule["ports"].(*schema.Set); ports.Len() > 0 {
 			return fmt.Errorf(

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -732,7 +732,7 @@ func verifyEgressFirewallParams(d *schema.ResourceData) error {
 
 	if !rules && !managed {
 		return fmt.Errorf(
-			"You must supply at least one 'rule' when not using the 'managed' firewall feature")
+			"you must supply at least one 'rule' when not using the 'managed' firewall feature")
 	}
 
 	return nil
@@ -749,12 +749,12 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 
 	if protocol == "icmp" {
 		if _, ok := rule["icmp_type"]; !ok {
-			return fmt.Errorf(
-				"Parameter icmp_type is a required parameter when using protocol 'icmp'")
+		return fmt.Errorf(
+			"parameter icmp_type is a required parameter when using protocol 'icmp'")
 		}
 		if _, ok := rule["icmp_code"]; !ok {
-			return fmt.Errorf(
-				"Parameter icmp_code is a required parameter when using protocol 'icmp'")
+		return fmt.Errorf(
+			"parameter icmp_code is a required parameter when using protocol 'icmp'")
 		}
 	} else if strings.ToLower(protocol) != "all" {
 		if ports, ok := rule["ports"].(*schema.Set); ok {
@@ -768,8 +768,8 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 		}
 	} else if strings.ToLower(protocol) == "all" {
 		if ports, _ := rule["ports"].(*schema.Set); ports.Len() > 0 {
-			return fmt.Errorf(
-				"Parameter ports is not required when using protocol 'ALL'")
+		return fmt.Errorf(
+			"parameter ports is not required when using protocol 'ALL'")
 		}
 	}
 

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -331,7 +331,7 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 			// by not setting startport and endport parameters
 			r, err := cs.Firewall.CreateEgressFirewallRule(p)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create all-ports egress firewall rule: %w", err)
 			}
 			uuids["all"] = r.Id
 			rule["uuids"] = uuids

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -762,3 +762,4 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 
 	return nil
 }
+// Formatting fix

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -21,6 +21,7 @@ package cloudstack
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,6 +31,81 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// treats 'all ports' for tcp/udp across CS versions returning 0/0, -1/-1, or 1/65535
+func isAllPortsTCPUDP(protocol string, start, end int) bool {
+	p := strings.ToLower(protocol)
+	if p != "tcp" && p != "udp" {
+		return false
+	}
+	// handle various representations of all ports across CloudStack versions
+	if (start == 0 && end == 0) ||
+		(start == -1 && end == -1) ||
+		(start == 1 && end == 65535) {
+		return true
+	}
+	return false
+}
+
+// normalizeRemoteCIDRs normalizes a comma-separated CIDR string from CloudStack API
+func normalizeRemoteCIDRs(cidrList string) []string {
+	if cidrList == "" {
+		return []string{}
+	}
+
+	cidrs := strings.Split(cidrList, ",")
+	normalized := make([]string, 0, len(cidrs))
+
+	for _, cidr := range cidrs {
+		trimmed := strings.TrimSpace(cidr)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+
+	sort.Strings(normalized)
+	return normalized
+}
+
+// normalizeLocalCIDRs normalizes a Terraform schema.Set of CIDRs
+func normalizeLocalCIDRs(cidrSet *schema.Set) []string {
+	if cidrSet == nil {
+		return []string{}
+	}
+
+	normalized := make([]string, 0, cidrSet.Len())
+	for _, cidr := range cidrSet.List() {
+		if cidrStr, ok := cidr.(string); ok {
+			trimmed := strings.TrimSpace(cidrStr)
+			if trimmed != "" {
+				normalized = append(normalized, trimmed)
+			}
+		}
+	}
+
+	sort.Strings(normalized)
+	return normalized
+}
+
+// cidrSetsEqual compares normalized CIDR sets for equality (order/whitespace agnostic)
+func cidrSetsEqual(remoteCidrList string, localCidrSet *schema.Set) bool {
+	remoteCidrs := normalizeRemoteCIDRs(remoteCidrList)
+	localCidrs := normalizeLocalCIDRs(localCidrSet)
+
+	// Compare lengths first
+	if len(remoteCidrs) != len(localCidrs) {
+		return false
+	}
+
+	// Compare each element (both are already sorted)
+	for i, remoteCidr := range remoteCidrs {
+		if remoteCidr != localCidrs[i] {
+			return false
+		}
+	}
+
+	return true
+}
 
 func resourceCloudStackEgressFirewall() *schema.Resource {
 	return &schema.Resource{
@@ -250,6 +326,15 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 				uuids[port.(string)] = r.Id
 				rule["uuids"] = uuids
 			}
+		} else {
+			// No ports specified - create a rule that encompasses all ports
+			// by not setting startport and endport parameters
+			r, err := cs.Firewall.CreateEgressFirewallRule(p)
+			if err != nil {
+				return err
+			}
+			uuids["all"] = r.Id
+			rule["uuids"] = uuids
 		}
 	}
 
@@ -368,8 +453,74 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 						rule["ports"] = ports
 						rules.Add(rule)
 					}
+				} else {
+					// No ports specified - check if we have an "all" rule
+					id, ok := uuids["all"]
+					if !ok {
+						continue
+					}
+
+					// Get the rule
+					r, ok := ruleMap[id.(string)]
+					if !ok {
+						delete(uuids, "all")
+						continue
+					}
+
+					// Verify this is actually an all-ports rule using our helper
+					if !isAllPortsTCPUDP(r.Protocol, r.Startport, r.Endport) {
+						// This rule has specific ports, but we expected all-ports
+						// This might happen if CloudStack behavior changed
+						continue
+					}
+
+					// Delete the known rule so only unknown rules remain in the ruleMap
+					delete(ruleMap, id.(string))
+
+					// Create a set with all CIDR's
+					cidrs := &schema.Set{F: schema.HashString}
+					for _, cidr := range strings.Split(r.Cidrlist, ",") {
+						cidrs.Add(cidr)
+					}
+
+					// Update the values
+					rule["protocol"] = r.Protocol
+					rule["cidr_list"] = cidrs
+					rules.Add(rule)
 				}
 			}
+
+			// Fallback: Check if any remaining rules in ruleMap match our expected all-ports pattern
+			// This handles cases where CloudStack might return all-ports rules in unexpected formats
+			if rule["protocol"].(string) != "icmp" && strings.ToLower(rule["protocol"].(string)) != "all" {
+				// Look for any remaining rules that might be our all-ports rule
+				for ruleID, r := range ruleMap {
+					// Get local CIDR set for comparison
+					localCidrSet, ok := rule["cidr_list"].(*schema.Set)
+					if !ok {
+						continue
+					}
+
+					if isAllPortsTCPUDP(r.Protocol, r.Startport, r.Endport) &&
+						strings.EqualFold(r.Protocol, rule["protocol"].(string)) &&
+						cidrSetsEqual(r.Cidrlist, localCidrSet) {
+						// This looks like our all-ports rule, add it to state
+						cidrs := &schema.Set{F: schema.HashString}
+						for _, cidr := range strings.Split(r.Cidrlist, ",") {
+							cidrs.Add(cidr)
+						}
+
+						rule["protocol"] = r.Protocol
+						rule["cidr_list"] = cidrs
+						rules.Add(rule)
+
+						// Remove from ruleMap so it's not processed again
+						delete(ruleMap, ruleID)
+						break
+					}
+				}
+			}
+
 			if strings.ToLower(rule["protocol"].(string)) == "all" {
 				id, ok := uuids["all"]
 				if !ok {
@@ -606,10 +757,9 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 						"%q is not a valid port value. Valid options are '80' or '80-90'", port.(string))
 				}
 			}
-		} else {
-			return fmt.Errorf(
-				"Parameter ports is a required parameter when *not* using protocol 'icmp'")
 		}
+		// Note: ports parameter is optional for TCP/UDP protocols
+		// When omitted, the rule will encompass all ports
 	} else if strings.ToLower(protocol) == "all" {
 		if ports, _ := rule["ports"].(*schema.Set); ports.Len() > 0 {
 			return fmt.Errorf(

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -400,8 +400,13 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 
 				// Create a set with all CIDR's
 				cidrs := &schema.Set{F: schema.HashString}
-				for _, cidr := range strings.Split(r.Cidrlist, ",") {
-					cidrs.Add(cidr)
+				if r.Cidrlist != "" {
+					for _, cidr := range strings.Split(r.Cidrlist, ",") {
+						cidr = strings.TrimSpace(cidr)
+						if cidr != "" {
+							cidrs.Add(cidr)
+						}
+					}
 				}
 
 				// Update the values
@@ -438,8 +443,13 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 
 						// Create a set with all CIDR's
 						cidrs := &schema.Set{F: schema.HashString}
-						for _, cidr := range strings.Split(r.Cidrlist, ",") {
-							cidrs.Add(cidr)
+						if r.Cidrlist != "" {
+							for _, cidr := range strings.Split(r.Cidrlist, ",") {
+								cidr = strings.TrimSpace(cidr)
+								if cidr != "" {
+									cidrs.Add(cidr)
+								}
+							}
 						}
 
 						// Update the values
@@ -479,45 +489,19 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 
 					// Create a set with all CIDR's
 					cidrs := &schema.Set{F: schema.HashString}
-					for _, cidr := range strings.Split(r.Cidrlist, ",") {
-						cidrs.Add(cidr)
+					if r.Cidrlist != "" {
+						for _, cidr := range strings.Split(r.Cidrlist, ",") {
+							cidr = strings.TrimSpace(cidr)
+							if cidr != "" {
+								cidrs.Add(cidr)
+							}
+						}
 					}
 
 					// Update the values
 					rule["protocol"] = r.Protocol
 					rule["cidr_list"] = cidrs
 					rules.Add(rule)
-				}
-			}
-
-			// Fallback: Check if any remaining rules in ruleMap match our expected all-ports pattern
-			// This handles cases where CloudStack might return all-ports rules in unexpected formats
-			if rule["protocol"].(string) != "icmp" && strings.ToLower(rule["protocol"].(string)) != "all" {
-				// Look for any remaining rules that might be our all-ports rule
-				for ruleID, r := range ruleMap {
-					// Get local CIDR set for comparison
-					localCidrSet, ok := rule["cidr_list"].(*schema.Set)
-					if !ok {
-						continue
-					}
-
-					if isAllPortsTCPUDP(r.Protocol, r.Startport, r.Endport) &&
-						strings.EqualFold(r.Protocol, rule["protocol"].(string)) &&
-						cidrSetsEqual(r.Cidrlist, localCidrSet) {
-						// This looks like our all-ports rule, add it to state
-						cidrs := &schema.Set{F: schema.HashString}
-						for _, cidr := range strings.Split(r.Cidrlist, ",") {
-							cidrs.Add(cidr)
-						}
-
-						rule["protocol"] = r.Protocol
-						rule["cidr_list"] = cidrs
-						rules.Add(rule)
-
-						// Remove from ruleMap so it's not processed again
-						delete(ruleMap, ruleID)
-						break
-					}
 				}
 			}
 
@@ -540,8 +524,13 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 				// Create a set with all CIDR's
 				if _, ok := rule["cidr_list"]; ok {
 					cidrs := &schema.Set{F: schema.HashString}
-					for _, cidr := range strings.Split(r.Cidrlist, ",") {
-						cidrs.Add(cidr)
+					if r.Cidrlist != "" {
+						for _, cidr := range strings.Split(r.Cidrlist, ",") {
+							cidr = strings.TrimSpace(cidr)
+							if cidr != "" {
+								cidrs.Add(cidr)
+							}
+						}
 					}
 					rule["cidr_list"] = cidrs
 				}

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -762,4 +762,5 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 
 	return nil
 }
+
 // Formatting fix

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -335,6 +335,8 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 			}
 			uuids["all"] = r.Id
 			rule["uuids"] = uuids
+			// Clear the ports field since we're creating an all-ports rule
+			rule["ports"] = &schema.Set{F: schema.HashString}
 		}
 	}
 
@@ -486,6 +488,8 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 					// Update the values
 					rule["protocol"] = r.Protocol
 					rule["cidr_list"] = cidrs
+					// Clear ports field for all-ports rules
+					rule["ports"] = &schema.Set{F: schema.HashString}
 					rules.Add(rule)
 				}
 			}
@@ -512,6 +516,8 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 
 						rule["protocol"] = r.Protocol
 						rule["cidr_list"] = cidrs
+						// Clear ports field for all-ports rules
+						rule["ports"] = &schema.Set{F: schema.HashString}
 						rules.Add(rule)
 
 						// Remove from ruleMap so it's not processed again

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// treats 'all ports' for tcp/udp across CS versions returning 0/0, -1/-1, or 1/65535
+// isAllPortsTCPUDP determines if a rule represents all ports for TCP/UDP protocols across CloudStack versions that may return 0/0, -1/-1, or 1/65535
 func isAllPortsTCPUDP(protocol string, start, end int) bool {
 	p := strings.ToLower(protocol)
 	if p != "tcp" && p != "udp" {
@@ -732,6 +732,8 @@ func verifyEgressFirewallParams(d *schema.ResourceData) error {
 	return nil
 }
 
+// verifyEgressFirewallRuleParams validates egress firewall rule parameters.
+// Note: ports parameter is optional for TCP/UDP protocols - when omitted, the rule will encompass all ports
 func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
 	protocol := rule["protocol"].(string)
 	if strings.ToLower(protocol) != "all" && protocol != "tcp" && protocol != "udp" && protocol != "icmp" {
@@ -758,8 +760,6 @@ func verifyEgressFirewallRuleParams(d *schema.ResourceData, rule map[string]inte
 				}
 			}
 		}
-		// Note: ports parameter is optional for TCP/UDP protocols
-		// When omitted, the rule will encompass all ports
 	} else if strings.ToLower(protocol) == "all" {
 		if ports, _ := rule["ports"].(*schema.Set); ports.Len() > 0 {
 			return fmt.Errorf(

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -331,10 +331,12 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 			// by not setting startport and endport parameters
 			r, err := cs.Firewall.CreateEgressFirewallRule(p)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create all-ports egress firewall rule: %w", err)
 			}
 			uuids["all"] = r.Id
 			rule["uuids"] = uuids
+			// Remove the ports field since we're creating an all-ports rule
+			delete(rule, "ports")
 		}
 	}
 
@@ -501,6 +503,8 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 					// Update the values
 					rule["protocol"] = r.Protocol
 					rule["cidr_list"] = cidrs
+					// Remove ports field for all-ports rules
+					delete(rule, "ports")
 					rules.Add(rule)
 				}
 			}

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -335,8 +335,8 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 			}
 			uuids["all"] = r.Id
 			rule["uuids"] = uuids
-			// Clear the ports field since we're creating an all-ports rule
-			rule["ports"] = &schema.Set{F: schema.HashString}
+			// Remove the ports field since we're creating an all-ports rule
+			delete(rule, "ports")
 		}
 	}
 
@@ -488,8 +488,8 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 					// Update the values
 					rule["protocol"] = r.Protocol
 					rule["cidr_list"] = cidrs
-					// Clear ports field for all-ports rules
-					rule["ports"] = &schema.Set{F: schema.HashString}
+					// Remove ports field for all-ports rules
+					delete(rule, "ports")
 					rules.Add(rule)
 				}
 			}
@@ -516,8 +516,8 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 
 						rule["protocol"] = r.Protocol
 						rule["cidr_list"] = cidrs
-						// Clear ports field for all-ports rules
-						rule["ports"] = &schema.Set{F: schema.HashString}
+						// Remove ports field for all-ports rules
+						delete(rule, "ports")
 						rules.Add(rule)
 
 						// Remove from ruleMap so it's not processed again

--- a/cloudstack/resource_cloudstack_egress_firewall_test.go
+++ b/cloudstack/resource_cloudstack_egress_firewall_test.go
@@ -202,3 +202,197 @@ resource "cloudstack_egress_firewall" "foo" {
     ports = ["80", "1000-2000"]
   }
 }`
+
+func TestAccCloudStackEgressFirewall_allPortsTCP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackEgressFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackEgressFirewall_allPorts,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackEgressFirewallRulesExist("cloudstack_egress_firewall.foo"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_egress_firewall.foo", "rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_egress_firewall.foo", "rule.0.cidr_list.0", "10.1.1.10/32"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_egress_firewall.foo", "rule.0.protocol", "tcp"),
+					// No ports should be set when omitting the ports parameter
+					resource.TestCheckNoResourceAttr(
+						"cloudstack_egress_firewall.foo", "rule.0.ports"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackEgressFirewall_allPorts = `
+resource "cloudstack_network" "foo" {
+  name = "terraform-network-tcp"
+  display_text = "terraform-network-tcp"
+  cidr = "10.1.1.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone = "Sandbox-simulator"
+}
+
+resource "cloudstack_egress_firewall" "foo" {
+  network_id = cloudstack_network.foo.id
+
+  rule {
+    cidr_list = ["10.1.1.10/32"]
+    protocol  = "tcp"
+    # No ports specified - should create a rule for all ports
+  }
+}`
+
+func TestAccCloudStackEgressFirewall_allPortsUDP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackEgressFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackEgressFirewall_allPortsUDP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackEgressFirewallRulesExist("cloudstack_egress_firewall.foo"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.foo", "rule.#", "1"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.foo", "rule.0.protocol", "udp"),
+					resource.TestCheckNoResourceAttr("cloudstack_egress_firewall.foo", "rule.0.ports"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackEgressFirewall_allPortsUDP = `
+resource "cloudstack_network" "foo" {
+  name             = "tf-egress-udp-all"
+  display_text     = "tf-egress-udp-all"
+  cidr             = "10.8.0.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone             = "Sandbox-simulator"
+}
+
+resource "cloudstack_egress_firewall" "foo" {
+  network_id = cloudstack_network.foo.id
+
+  rule {
+    cidr_list = ["10.8.0.10/32"]
+    protocol  = "udp"
+    # no ports => all ports
+  }
+}`
+
+func TestAccCloudStackEgressFirewall_allPortsCombined(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackEgressFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackEgressFirewall_allPortsCombined,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackEgressFirewallRulesExist("cloudstack_egress_firewall.mixed"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.mixed", "rule.#", "2"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.mixed", "rule.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.mixed", "rule.0.ports.#", "2"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.mixed", "rule.1.protocol", "udp"),
+					resource.TestCheckNoResourceAttr("cloudstack_egress_firewall.mixed", "rule.1.ports"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackEgressFirewall_allPortsCombined = `
+resource "cloudstack_network" "foo" {
+  name             = "terraform-network-mixed"
+  display_text     = "terraform-network-mixed"
+  cidr             = "10.1.3.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone             = "Sandbox-simulator"
+}
+
+resource "cloudstack_egress_firewall" "mixed" {
+  network_id = cloudstack_network.foo.id
+
+  rule {
+    cidr_list = ["10.0.0.0/8"]
+    protocol  = "tcp"
+    ports     = ["80", "443"]
+  }
+
+  rule {
+    cidr_list = ["10.1.0.0/16"]
+    protocol  = "udp"
+    # no ports => all ports
+  }
+}`
+
+func TestAccCloudStackEgressFirewall_portsToAllPorts(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackEgressFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackEgressFirewall_specificPorts,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackEgressFirewallRulesExist("cloudstack_egress_firewall.foo"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.foo", "rule.#", "1"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.foo", "rule.0.ports.#", "2"),
+				),
+			},
+			{
+				Config: testAccCloudStackEgressFirewall_allPortsTransition,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackEgressFirewallRulesExist("cloudstack_egress_firewall.foo"),
+					resource.TestCheckResourceAttr("cloudstack_egress_firewall.foo", "rule.#", "1"),
+					resource.TestCheckNoResourceAttr("cloudstack_egress_firewall.foo", "rule.0.ports"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackEgressFirewall_specificPorts = `
+resource "cloudstack_network" "foo" {
+  name             = "terraform-network-transition"
+  display_text     = "terraform-network-transition"
+  cidr             = "10.1.4.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone             = "Sandbox-simulator"
+}
+
+resource "cloudstack_egress_firewall" "foo" {
+  network_id = cloudstack_network.foo.id
+
+  rule {
+    cidr_list = ["10.1.1.10/32"]
+    protocol  = "tcp"
+    ports     = ["80", "1000-2000"]
+  }
+}
+`
+
+const testAccCloudStackEgressFirewall_allPortsTransition = `
+resource "cloudstack_network" "foo" {
+  name             = "terraform-network-transition"
+  display_text     = "terraform-network-transition"
+  cidr             = "10.1.4.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone             = "Sandbox-simulator"
+}
+
+resource "cloudstack_egress_firewall" "foo" {
+  network_id = cloudstack_network.foo.id
+
+  rule {
+    cidr_list = ["10.1.1.10/32"]
+    protocol  = "tcp"
+    # no ports => all ports
+  }
+}
+`

--- a/cloudstack/resource_cloudstack_egress_firewall_unit_test.go
+++ b/cloudstack/resource_cloudstack_egress_firewall_unit_test.go
@@ -1,0 +1,155 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestIsAllPortsTCPUDP(t *testing.T) {
+	tests := []struct {
+		protocol string
+		start    int
+		end      int
+		expected bool
+		name     string
+	}{
+		{"tcp", 0, 0, true, "TCP with 0/0"},
+		{"TCP", 0, 0, true, "TCP uppercase with 0/0"},
+		{"udp", -1, -1, true, "UDP with -1/-1"},
+		{"UDP", -1, -1, true, "UDP uppercase with -1/-1"},
+		{"tcp", 1, 65535, true, "TCP with 1/65535"},
+		{"udp", 1, 65535, true, "UDP with 1/65535"},
+		{"tcp", 80, 80, false, "TCP with specific port"},
+		{"udp", 53, 53, false, "UDP with specific port"},
+		{"icmp", 0, 0, false, "ICMP protocol"},
+		{"all", 0, 0, false, "ALL protocol"},
+		{"tcp", 1, 1000, false, "TCP with port range"},
+		{"tcp", 0, 1, false, "TCP with 0/1"},
+		{"tcp", -1, 0, false, "TCP with -1/0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := isAllPortsTCPUDP(test.protocol, test.start, test.end)
+			if result != test.expected {
+				t.Errorf("isAllPortsTCPUDP(%q, %d, %d) = %v, expected %v",
+					test.protocol, test.start, test.end, result, test.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeRemoteCIDRs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+		name     string
+	}{
+		{"", []string{}, "empty string"},
+		{"10.0.0.0/8", []string{"10.0.0.0/8"}, "single CIDR"},
+		{"10.0.0.0/8,192.168.1.0/24", []string{"10.0.0.0/8", "192.168.1.0/24"}, "two CIDRs"},
+		{"10.0.0.0/8, 192.168.1.0/24", []string{"10.0.0.0/8", "192.168.1.0/24"}, "two CIDRs with space"},
+		{" 10.0.0.0/8 , 192.168.1.0/24 ", []string{"10.0.0.0/8", "192.168.1.0/24"}, "CIDRs with extra spaces"},
+		{"192.168.1.0/24,10.0.0.0/8", []string{"10.0.0.0/8", "192.168.1.0/24"}, "unsorted CIDRs (should be sorted)"},
+		{"10.0.0.0/8,,192.168.1.0/24", []string{"10.0.0.0/8", "192.168.1.0/24"}, "empty CIDR in middle"},
+		{" , , ", []string{}, "only commas and spaces"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := normalizeRemoteCIDRs(test.input)
+			if len(result) != len(test.expected) {
+				t.Errorf("normalizeRemoteCIDRs(%q) length = %d, expected %d",
+					test.input, len(result), len(test.expected))
+				return
+			}
+			for i, v := range result {
+				if v != test.expected[i] {
+					t.Errorf("normalizeRemoteCIDRs(%q)[%d] = %q, expected %q",
+						test.input, i, v, test.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeLocalCIDRs(t *testing.T) {
+	tests := []struct {
+		input    *schema.Set
+		expected []string
+		name     string
+	}{
+		{nil, []string{}, "nil set"},
+		{schema.NewSet(schema.HashString, []interface{}{}), []string{}, "empty set"},
+		{schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}), []string{"10.0.0.0/8"}, "single CIDR"},
+		{schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8", "192.168.1.0/24"}), []string{"10.0.0.0/8", "192.168.1.0/24"}, "two CIDRs"},
+		{schema.NewSet(schema.HashString, []interface{}{"192.168.1.0/24", "10.0.0.0/8"}), []string{"10.0.0.0/8", "192.168.1.0/24"}, "unsorted CIDRs"},
+		{schema.NewSet(schema.HashString, []interface{}{" 10.0.0.0/8 ", " 192.168.1.0/24 "}), []string{"10.0.0.0/8", "192.168.1.0/24"}, "CIDRs with spaces"},
+		{schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8", "", "192.168.1.0/24"}), []string{"10.0.0.0/8", "192.168.1.0/24"}, "with empty string"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := normalizeLocalCIDRs(test.input)
+			if len(result) != len(test.expected) {
+				t.Errorf("normalizeLocalCIDRs() length = %d, expected %d",
+					len(result), len(test.expected))
+				return
+			}
+			for i, v := range result {
+				if v != test.expected[i] {
+					t.Errorf("normalizeLocalCIDRs()[%d] = %q, expected %q",
+						i, v, test.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCidrSetsEqual(t *testing.T) {
+	tests := []struct {
+		remote   string
+		local    *schema.Set
+		expected bool
+		name     string
+	}{
+		{"", schema.NewSet(schema.HashString, []interface{}{}), true, "both empty"},
+		{"10.0.0.0/8", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}), true, "single matching CIDR"},
+		{"10.0.0.0/8,192.168.1.0/24", schema.NewSet(schema.HashString, []interface{}{"192.168.1.0/24", "10.0.0.0/8"}), true, "multiple CIDRs different order"},
+		{"10.0.0.0/8, 192.168.1.0/24", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8", "192.168.1.0/24"}), true, "remote with spaces"},
+		{"10.0.0.0/8", schema.NewSet(schema.HashString, []interface{}{"192.168.1.0/24"}), false, "different CIDRs"},
+		{"10.0.0.0/8,192.168.1.0/24", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}), false, "different count"},
+		{"", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}), false, "remote empty, local not"},
+		{"10.0.0.0/8", schema.NewSet(schema.HashString, []interface{}{}), false, "local empty, remote not"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := cidrSetsEqual(test.remote, test.local)
+			if result != test.expected {
+				t.Errorf("cidrSetsEqual(%q, %v) = %v, expected %v",
+					test.remote, test.local.List(), result, test.expected)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -85,5 +84,3 @@ require (
 )
 
 go 1.23.0
-
-toolchain go1.22.4

--- a/go.sum
+++ b/go.sum
@@ -168,7 +168,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/website/docs/r/egress_firewall.html.markdown
+++ b/website/docs/r/egress_firewall.html.markdown
@@ -24,6 +24,56 @@ resource "cloudstack_egress_firewall" "default" {
 }
 ```
 
+### Example: All Ports Rule
+
+To create a rule that encompasses all ports for a protocol, simply omit the `ports` parameter:
+
+```hcl
+resource "cloudstack_egress_firewall" "all_ports" {
+  network_id = "6eb22f91-7454-4107-89f4-36afcdf33021"
+
+  rule {
+    cidr_list = ["10.0.0.0/8"]
+    protocol  = "tcp"
+    # No ports specified - rule will encompass all TCP ports
+  }
+}
+```
+
+### Example: UDP All Ports
+
+```hcl
+resource "cloudstack_egress_firewall" "all_ports_udp" {
+  network_id = "6eb22f91-7454-4107-89f4-36afcdf33021"
+
+  rule {
+    cidr_list = ["10.1.0.0/16"]
+    protocol  = "udp"
+    # No ports => all UDP ports
+  }
+}
+```
+
+### Example: Mixed Rules (specific + all-ports)
+
+```hcl
+resource "cloudstack_egress_firewall" "mixed_rules" {
+  network_id = "6eb22f91-7454-4107-89f4-36afcdf33021"
+
+  rule {
+    cidr_list = ["10.0.0.0/8"]
+    protocol  = "tcp"
+    ports     = ["80", "443"]
+  }
+
+  rule {
+    cidr_list = ["10.1.0.0/16"]
+    protocol  = "udp"
+    # No ports => all UDP ports
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -55,7 +105,7 @@ The `rule` block supports:
     the protocol is ICMP.
 
 * `ports` - (Optional) List of ports and/or port ranges to allow. This can only
-    be specified if the protocol is TCP or UDP.
+    be specified if the protocol is TCP or UDP. For TCP/UDP, omitting `ports` creates an all-ports rule. CloudStack may represent this as empty start/end, `0/0`, or `1/65535`; the provider handles all.
 
 ## Attributes Reference
 

--- a/website/docs/r/egress_firewall.html.markdown
+++ b/website/docs/r/egress_firewall.html.markdown
@@ -105,7 +105,7 @@ The `rule` block supports:
     the protocol is ICMP.
 
 * `ports` - (Optional) List of ports and/or port ranges to allow. This can only
-    be specified if the protocol is TCP or UDP. For TCP/UDP, omitting `ports` creates an all-ports rule. CloudStack may represent this as empty start/end, `0/0`, or `1/65535`; the provider handles all.
+    be specified if the protocol is TCP or UDP. For TCP/UDP protocols, omitting `ports` creates an all-ports rule. CloudStack may represent this as empty start/end ports, `0/0`, or `1/65535`; the provider handles all formats.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Allow omitting ports parameter for TCP/UDP protocols to create rules that encompass all ports
- Update validation to make ports parameter optional for TCP/UDP protocols
- Add support for reading rules created without explicit ports
- Add test case for all-ports functionality
- Update documentation with example and clarification

Fixes #202