### PR TITLE
feat: make cidr optional for L2 networks

### DIFF
--- a/cloudstack/resource_cloudstack_configuration.go
+++ b/cloudstack/resource_cloudstack_configuration.go
@@ -163,10 +163,7 @@ func resourceCloudStackConfigurationCreate(d *schema.ResourceData, meta interfac
 		d.SetId(v.(string))
 	}
 
-	resourceCloudStackConfigurationUpdate(d, meta)
-
-	return nil
-
+	return resourceCloudStackConfigurationUpdate(d, meta)
 }
 
 func resourceCloudStackConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -201,9 +198,7 @@ func resourceCloudStackConfigurationUpdate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	resourceCloudStackConfigurationRead(d, meta)
-
-	return nil
+	return resourceCloudStackConfigurationRead(d, meta)
 }
 
 func resourceCloudStackConfigurationDelete(d *schema.ResourceData, meta interface{}) error {

--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -154,7 +154,7 @@ func resourceCloudStackInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"keypair": &schema.Schema{
+			"keypair": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"keypairs"},

--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -153,7 +153,7 @@ func resourceCloudStackInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"keypair": &schema.Schema{
+			"keypair": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"keypairs"},

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -177,17 +177,17 @@ func resourceCloudStackNetwork() *schema.Resource {
 func resourceCloudStackNetworkCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	networkType := d.Get("type").(string)
 	cidr := d.Get("cidr").(string)
-	
+
 	// For L3 networks, cidr is required
 	if networkType == "L3" && cidr == "" {
 		return fmt.Errorf("cidr is required when type is L3")
 	}
-	
+
 	// For L2 networks, cidr should not be provided
 	if networkType == "L2" && cidr != "" {
 		return fmt.Errorf("cidr should not be provided when type is L2")
 	}
-	
+
 	return nil
 }
 
@@ -346,7 +346,7 @@ func resourceCloudStackNetworkRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("gateway", n.Gateway)
 	d.Set("network_domain", n.Networkdomain)
 	d.Set("vpc_id", n.Vpcid)
-	
+
 	// Determine network type based on CIDR presence
 	if n.Cidr == "" {
 		d.Set("type", "L2")

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -20,6 +20,7 @@
 package cloudstack
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -59,6 +60,7 @@ func resourceCloudStackNetwork() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: importStatePassthrough,
 		},
+		CustomizeDiff: resourceCloudStackNetworkCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -70,6 +72,20 @@ func resourceCloudStackNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "L2" && v != "L3" {
+						errs = append(errs, fmt.Errorf("%q must be either 'L2' or 'L3', got: %s", key, v))
+					}
+					return
+				},
 			},
 
 			"cidr": {
@@ -215,6 +231,22 @@ func resourceCloudStackNetwork() *schema.Resource {
 	}
 }
 
+// resourceCloudStackNetworkCustomizeDiff validates the type and cidr
+// combination. When type is not set, it is filled in from the API response.
+func resourceCloudStackNetworkCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	networkType := d.Get("type").(string)
+	cidr := d.Get("cidr").(string)
+
+	if networkType == "L2" && cidr != "" {
+		return fmt.Errorf("cidr must not be set when type is L2")
+	}
+	if networkType == "L3" && cidr == "" {
+		return fmt.Errorf("cidr is required when type is L3")
+	}
+
+	return nil
+}
+
 func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 
@@ -247,6 +279,7 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	// L2 networks have no cidr, so no IP config is sent for them
 	if _, ok := d.GetOk("cidr"); ok {
 		m, err := parseCIDR(d, no.Specifyipranges)
 		if err != nil {
@@ -422,6 +455,13 @@ func resourceCloudStackNetworkRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("network_domain", n.Networkdomain)
 	d.Set("vpc_id", n.Vpcid)
 
+	// CloudStack returns "L2" for L2 networks and "Isolated"/"Shared" for L3 networks
+	if n.Type == "L2" {
+		d.Set("type", "L2")
+	} else {
+		d.Set("type", "L3")
+	}
+
 	// Always set IPv6 fields to detect drift when IPv6 is removed server-side
 	d.Set("ip6cidr", n.Ip6cidr)
 	d.Set("ip6gateway", n.Ip6gateway)
@@ -562,7 +602,17 @@ func resourceCloudStackNetworkDelete(d *schema.ResourceData, meta interface{}) e
 func parseCIDR(d *schema.ResourceData, specifyiprange bool) (map[string]string, error) {
 	m := make(map[string]string, 4)
 
+	// L2 networks have no IP config to parse
+	networkType := d.Get("type").(string)
+	if networkType == "L2" {
+		return m, nil
+	}
+
 	cidr := d.Get("cidr").(string)
+	if cidr == "" {
+		return nil, fmt.Errorf("cidr is required for L3 networks")
+	}
+
 	ip, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse cidr %s: %s", cidr, err)

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -231,8 +231,7 @@ func resourceCloudStackNetwork() *schema.Resource {
 	}
 }
 
-// resourceCloudStackNetworkCustomizeDiff validates the type and cidr
-// combination. When type is not set, it is filled in from the API response.
+// resourceCloudStackNetworkCustomizeDiff validates the type and cidr combination.
 func resourceCloudStackNetworkCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	networkType := d.Get("type").(string)
 	cidr := d.Get("cidr").(string)
@@ -279,7 +278,7 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	// L2 networks have no cidr, so no IP config is sent for them
+	// Send IPv4 gateway/netmask only when cidr is set
 	if _, ok := d.GetOk("cidr"); ok {
 		m, err := parseCIDR(d, no.Specifyipranges)
 		if err != nil {
@@ -602,9 +601,11 @@ func resourceCloudStackNetworkDelete(d *schema.ResourceData, meta interface{}) e
 func parseCIDR(d *schema.ResourceData, specifyiprange bool) (map[string]string, error) {
 	m := make(map[string]string, 4)
 
-	// L2 networks have no IP config to parse
 	networkType := d.Get("type").(string)
 	if networkType == "L2" {
+		if d.Get("cidr").(string) != "" {
+			return nil, fmt.Errorf("cidr must not be set when type is L2")
+		}
 		return m, nil
 	}
 

--- a/cloudstack/resource_cloudstack_network_parse_test.go
+++ b/cloudstack/resource_cloudstack_network_parse_test.go
@@ -1,3 +1,22 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
 package cloudstack
 
 import (

--- a/cloudstack/resource_cloudstack_network_parse_test.go
+++ b/cloudstack/resource_cloudstack_network_parse_test.go
@@ -27,14 +27,14 @@ import (
 
 func TestParseCIDR(t *testing.T) {
 	networkResource := resourceCloudStackNetwork()
-	
+
 	t.Run("L2 network should return empty map", func(t *testing.T) {
 		config := map[string]interface{}{
 			"type": "L2",
 		}
-		
+
 		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
-		
+
 		result, err := parseCIDR(resourceData, false)
 		if err != nil {
 			t.Errorf("Expected no error for L2 network, got: %v", err)
@@ -46,15 +46,15 @@ func TestParseCIDR(t *testing.T) {
 			t.Errorf("Expected empty map for L2 network, got: %v", result)
 		}
 	})
-	
+
 	t.Run("L3 network with valid CIDR should parse correctly", func(t *testing.T) {
 		config := map[string]interface{}{
 			"type": "L3",
 			"cidr": "10.0.0.0/16",
 		}
-		
+
 		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
-		
+
 		result, err := parseCIDR(resourceData, true)
 		if err != nil {
 			t.Errorf("Expected no error for L3 network with valid CIDR, got: %v", err)
@@ -69,14 +69,14 @@ func TestParseCIDR(t *testing.T) {
 			t.Error("Expected netmask to be set")
 		}
 	})
-	
+
 	t.Run("L3 network without CIDR should return error", func(t *testing.T) {
 		config := map[string]interface{}{
 			"type": "L3",
 		}
-		
+
 		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
-		
+
 		_, err := parseCIDR(resourceData, true)
 		if err == nil {
 			t.Error("Expected error for L3 network without CIDR, but got none")

--- a/cloudstack/resource_cloudstack_network_parse_test.go
+++ b/cloudstack/resource_cloudstack_network_parse_test.go
@@ -1,0 +1,69 @@
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestParseCIDR(t *testing.T) {
+	networkResource := resourceCloudStackNetwork()
+	
+	t.Run("L2 network should return empty map", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L2",
+		}
+		
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+		
+		result, err := parseCIDR(resourceData, false)
+		if err != nil {
+			t.Errorf("Expected no error for L2 network, got: %v", err)
+		}
+		if result == nil {
+			t.Error("Expected non-nil result for L2 network")
+		}
+		if len(result) != 0 {
+			t.Errorf("Expected empty map for L2 network, got: %v", result)
+		}
+	})
+	
+	t.Run("L3 network with valid CIDR should parse correctly", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L3",
+			"cidr": "10.0.0.0/16",
+		}
+		
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+		
+		result, err := parseCIDR(resourceData, true)
+		if err != nil {
+			t.Errorf("Expected no error for L3 network with valid CIDR, got: %v", err)
+		}
+		if result == nil {
+			t.Error("Expected non-nil result for L3 network")
+		}
+		if result["gateway"] == "" {
+			t.Error("Expected gateway to be set")
+		}
+		if result["netmask"] == "" {
+			t.Error("Expected netmask to be set")
+		}
+	})
+	
+	t.Run("L3 network without CIDR should return error", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L3",
+		}
+		
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+		
+		_, err := parseCIDR(resourceData, true)
+		if err == nil {
+			t.Error("Expected error for L3 network without CIDR, but got none")
+		}
+		if err != nil && err.Error() != "cidr is required for L3 networks" {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+}

--- a/cloudstack/resource_cloudstack_network_parse_test.go
+++ b/cloudstack/resource_cloudstack_network_parse_test.go
@@ -1,0 +1,88 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestParseCIDR(t *testing.T) {
+	networkResource := resourceCloudStackNetwork()
+
+	t.Run("L2 network should return empty map", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L2",
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+
+		result, err := parseCIDR(resourceData, false)
+		if err != nil {
+			t.Errorf("Expected no error for L2 network, got: %v", err)
+		}
+		if result == nil {
+			t.Error("Expected non-nil result for L2 network")
+		}
+		if len(result) != 0 {
+			t.Errorf("Expected empty map for L2 network, got: %v", result)
+		}
+	})
+
+	t.Run("L3 network with valid CIDR should parse correctly", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L3",
+			"cidr": "10.0.0.0/16",
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+
+		result, err := parseCIDR(resourceData, true)
+		if err != nil {
+			t.Errorf("Expected no error for L3 network with valid CIDR, got: %v", err)
+		}
+		if result == nil {
+			t.Error("Expected non-nil result for L3 network")
+		}
+		if result["gateway"] == "" {
+			t.Error("Expected gateway to be set")
+		}
+		if result["netmask"] == "" {
+			t.Error("Expected netmask to be set")
+		}
+	})
+
+	t.Run("L3 network without CIDR should return error", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L3",
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+
+		_, err := parseCIDR(resourceData, true)
+		if err == nil {
+			t.Error("Expected error for L3 network without CIDR, but got none")
+		}
+		if err != nil && err.Error() != "cidr is required for L3 networks" {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+}

--- a/cloudstack/resource_cloudstack_network_parse_test.go
+++ b/cloudstack/resource_cloudstack_network_parse_test.go
@@ -70,6 +70,20 @@ func TestParseCIDR(t *testing.T) {
 		}
 	})
 
+	t.Run("L2 network with CIDR should return error", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type": "L2",
+			"cidr": "10.0.0.0/16",
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, networkResource.Schema, config)
+
+		_, err := parseCIDR(resourceData, false)
+		if err == nil {
+			t.Error("Expected error for L2 network with CIDR, but got none")
+		}
+	})
+
 	t.Run("L3 network without CIDR should return error", func(t *testing.T) {
 		config := map[string]interface{}{
 			"type": "L3",

--- a/cloudstack/resource_cloudstack_network_test.go
+++ b/cloudstack/resource_cloudstack_network_test.go
@@ -285,6 +285,26 @@ func TestAccCloudStackNetwork_ipv6_custom_gateway(t *testing.T) {
 	})
 }
 
+func TestAccCloudStackNetwork_L2(t *testing.T) {
+	var network cloudstack.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackNetwork_L2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackNetworkExists(
+						"cloudstack_network.foo", &network),
+					testAccCheckCloudStackNetworkL2Attributes(&network),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudStackNetworkExists(
 	n string, network *cloudstack.Network) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -358,6 +378,31 @@ func testAccCheckCloudStackNetworkVPCAttributes(
 
 		if network.Networkofferingname != "DefaultIsolatedNetworkOfferingForVpcNetworks" {
 			return fmt.Errorf("Bad network offering: %s", network.Networkofferingname)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackNetworkL2Attributes(
+	network *cloudstack.Network) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if network.Name != "terraform-l2-network" {
+			return fmt.Errorf("Bad name: %s", network.Name)
+		}
+
+		if network.Displaytext != "terraform-l2-network" {
+			return fmt.Errorf("Bad display name: %s", network.Displaytext)
+		}
+
+		if network.Type != "L2" {
+			return fmt.Errorf("Bad network type: %s", network.Type)
+		}
+
+		// L2 networks should not have a CIDR
+		if network.Cidr != "" {
+			return fmt.Errorf("L2 network should not have CIDR, got: %s", network.Cidr)
 		}
 
 		return nil
@@ -536,6 +581,15 @@ resource "cloudstack_network" "foo" {
   vpc_id = cloudstack_vpc.foo.id
   acl_id = cloudstack_network_acl.bar.id
   zone = cloudstack_vpc.foo.zone
+}`
+
+const testAccCloudStackNetwork_L2 = `
+resource "cloudstack_network" "foo" {
+  name = "terraform-l2-network"
+  display_text = "terraform-l2-network"
+  type = "L2"
+  network_offering = "DefaultL2NetworkOffering"
+  zone = "Sandbox-simulator"
 }`
 
 func TestAccCloudStackNetwork_l2NoCidr(t *testing.T) {

--- a/cloudstack/resource_cloudstack_network_validation_test.go
+++ b/cloudstack/resource_cloudstack_network_validation_test.go
@@ -1,3 +1,22 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
 package cloudstack
 
 import (

--- a/cloudstack/resource_cloudstack_network_validation_test.go
+++ b/cloudstack/resource_cloudstack_network_validation_test.go
@@ -1,0 +1,50 @@
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceCloudStackNetworkSchema(t *testing.T) {
+	networkResource := resourceCloudStackNetwork()
+	
+	// Test that required fields exist
+	t.Run("Schema should have type field", func(t *testing.T) {
+		if typeField, ok := networkResource.Schema["type"]; !ok {
+			t.Error("Schema should have 'type' field")
+		} else {
+			if typeField.Type != schema.TypeString {
+				t.Errorf("Type field should be TypeString, got: %v", typeField.Type)
+			}
+			if typeField.Required {
+				t.Error("Type field should not be required")
+			}
+			if typeField.Optional != true {
+				t.Error("Type field should be optional")
+			}
+			if typeField.Default != "L3" {
+				t.Errorf("Type field default should be 'L3', got: %v", typeField.Default)
+			}
+		}
+	})
+	
+	t.Run("Schema should have cidr field as optional", func(t *testing.T) {
+		if cidrField, ok := networkResource.Schema["cidr"]; !ok {
+			t.Error("Schema should have 'cidr' field")
+		} else {
+			if cidrField.Required {
+				t.Error("CIDR field should not be required")
+			}
+			if cidrField.Optional != true {
+				t.Error("CIDR field should be optional")
+			}
+		}
+	})
+	
+	t.Run("Schema should have CustomizeDiff", func(t *testing.T) {
+		if networkResource.CustomizeDiff == nil {
+			t.Error("Resource should have CustomizeDiff function")
+		}
+	})
+}

--- a/cloudstack/resource_cloudstack_network_validation_test.go
+++ b/cloudstack/resource_cloudstack_network_validation_test.go
@@ -42,8 +42,11 @@ func TestResourceCloudStackNetworkSchema(t *testing.T) {
 			if typeField.Optional != true {
 				t.Error("Type field should be optional")
 			}
-			if typeField.Default != "L3" {
-				t.Errorf("Type field default should be 'L3', got: %v", typeField.Default)
+			if typeField.Computed != true {
+				t.Error("Type field should be computed")
+			}
+			if typeField.Default != nil {
+				t.Errorf("Type field should not have a default (it's computed), got: %v", typeField.Default)
 			}
 		}
 	})

--- a/cloudstack/resource_cloudstack_network_validation_test.go
+++ b/cloudstack/resource_cloudstack_network_validation_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestResourceCloudStackNetworkSchema(t *testing.T) {
 	networkResource := resourceCloudStackNetwork()
-	
+
 	// Test that required fields exist
 	t.Run("Schema should have type field", func(t *testing.T) {
 		if typeField, ok := networkResource.Schema["type"]; !ok {
@@ -47,7 +47,7 @@ func TestResourceCloudStackNetworkSchema(t *testing.T) {
 			}
 		}
 	})
-	
+
 	t.Run("Schema should have cidr field as optional", func(t *testing.T) {
 		if cidrField, ok := networkResource.Schema["cidr"]; !ok {
 			t.Error("Schema should have 'cidr' field")
@@ -60,7 +60,7 @@ func TestResourceCloudStackNetworkSchema(t *testing.T) {
 			}
 		}
 	})
-	
+
 	t.Run("Schema should have CustomizeDiff", func(t *testing.T) {
 		if networkResource.CustomizeDiff == nil {
 			t.Error("Resource should have CustomizeDiff function")

--- a/cloudstack/resource_cloudstack_network_validation_test.go
+++ b/cloudstack/resource_cloudstack_network_validation_test.go
@@ -1,0 +1,242 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestResourceCloudStackNetworkSchema(t *testing.T) {
+	networkResource := resourceCloudStackNetwork()
+
+	// Test that required fields exist
+	t.Run("Schema should have type field", func(t *testing.T) {
+		if typeField, ok := networkResource.Schema["type"]; !ok {
+			t.Error("Schema should have 'type' field")
+		} else {
+			if typeField.Type != schema.TypeString {
+				t.Errorf("Type field should be TypeString, got: %v", typeField.Type)
+			}
+			if typeField.Required {
+				t.Error("Type field should not be required")
+			}
+			if typeField.Optional != true {
+				t.Error("Type field should be optional")
+			}
+			if typeField.Computed != true {
+				t.Error("Type field should be computed")
+			}
+			if typeField.Default != nil {
+				t.Errorf("Type field should not have a default (it's computed), got: %v", typeField.Default)
+			}
+		}
+	})
+
+	t.Run("Schema should have cidr field as optional", func(t *testing.T) {
+		if cidrField, ok := networkResource.Schema["cidr"]; !ok {
+			t.Error("Schema should have 'cidr' field")
+		} else {
+			if cidrField.Required {
+				t.Error("CIDR field should not be required")
+			}
+			if cidrField.Optional != true {
+				t.Error("CIDR field should be optional")
+			}
+		}
+	})
+
+	t.Run("Schema should have CustomizeDiff", func(t *testing.T) {
+		if networkResource.CustomizeDiff == nil {
+			t.Error("Resource should have CustomizeDiff function")
+		}
+	})
+}
+
+func diffNetwork(t *testing.T, state *terraform.InstanceState, raw map[string]interface{}) (*terraform.InstanceDiff, error) {
+	t.Helper()
+	r := resourceCloudStackNetwork()
+	c := terraform.NewResourceConfigRaw(raw)
+	return r.Diff(context.Background(), state, c, nil)
+}
+
+func TestResourceCloudStackNetworkTypeCidrDiff(t *testing.T) {
+	t.Run("new L2 network with explicit type and no cidr plans cleanly", func(t *testing.T) {
+		d, err := diffNetwork(t, nil, map[string]interface{}{
+			"name":             "terraform-l2-network",
+			"type":             "L2",
+			"network_offering": "DefaultL2NetworkOffering",
+			"zone":             "Sandbox-simulator",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d == nil {
+			t.Fatal("expected a diff for new resource")
+		}
+		if attr, ok := d.Attributes["type"]; !ok || attr.New != "L2" {
+			t.Fatalf("expected planned type L2, got %+v", d.Attributes["type"])
+		}
+	})
+
+	t.Run("new isolated network without cidr and without type plans cleanly", func(t *testing.T) {
+		d, err := diffNetwork(t, nil, map[string]interface{}{
+			"name":             "terraform-isolated-no-cidr",
+			"network_offering": "DefaultIsolatedNetworkOfferingWithSourceNatService",
+			"zone":             "Sandbox-simulator",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// type should stay computed so the value from the API is accepted after apply
+		if attr, ok := d.Attributes["type"]; ok && !attr.NewComputed && attr.New != "" {
+			t.Fatalf("type should remain computed, got %+v", attr)
+		}
+		if attr, ok := d.Attributes["cidr"]; ok && !attr.NewComputed && attr.New != "" {
+			t.Fatalf("cidr should remain computed, got %+v", attr)
+		}
+	})
+
+	t.Run("new L3 network with cidr plans cleanly", func(t *testing.T) {
+		_, err := diffNetwork(t, nil, map[string]interface{}{
+			"name":             "terraform-network",
+			"cidr":             "10.1.1.0/24",
+			"network_offering": "DefaultIsolatedNetworkOfferingWithSourceNatService",
+			"zone":             "Sandbox-simulator",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("L2 with cidr is rejected", func(t *testing.T) {
+		_, err := diffNetwork(t, nil, map[string]interface{}{
+			"name":             "terraform-l2-network",
+			"type":             "L2",
+			"cidr":             "10.1.1.0/24",
+			"network_offering": "DefaultL2NetworkOffering",
+			"zone":             "Sandbox-simulator",
+		})
+		if err == nil {
+			t.Fatal("expected error for L2 network with cidr")
+		}
+	})
+
+	t.Run("explicit L3 without cidr is rejected", func(t *testing.T) {
+		_, err := diffNetwork(t, nil, map[string]interface{}{
+			"name":             "terraform-network",
+			"type":             "L3",
+			"network_offering": "DefaultIsolatedNetworkOfferingWithSourceNatService",
+			"zone":             "Sandbox-simulator",
+		})
+		if err == nil {
+			t.Fatal("expected error for explicit L3 network without cidr")
+		}
+	})
+
+	t.Run("existing isolated network created without cidr shows no drift", func(t *testing.T) {
+		// state as it looks after creating an isolated network without cidr
+		state := &terraform.InstanceState{
+			ID: "net-1",
+			Attributes: map[string]string{
+				"id":                        "net-1",
+				"name":                      "terraform-isolated-no-cidr",
+				"display_text":              "terraform-isolated-no-cidr",
+				"type":                      "L3",
+				"cidr":                      "10.1.1.0/24",
+				"gateway":                   "10.1.1.1",
+				"ip6cidr":                   "",
+				"ip6gateway":                "",
+				"startip":                   "",
+				"endip":                     "",
+				"startipv6":                 "",
+				"endipv6":                   "",
+				"network_domain":            "cs1cloud.internal",
+				"network_offering":          "DefaultIsolatedNetworkOfferingWithSourceNatService",
+				"vpc_id":                    "",
+				"acl_id":                    "none",
+				"project":                   "",
+				"source_nat_ip":             "false",
+				"source_nat_ip_address":     "",
+				"source_nat_ip_id":          "",
+				"zone":                      "Sandbox-simulator",
+				"bypass_vlan_overlap_check": "false",
+				"tags.%":                    "0",
+			},
+		}
+		d, err := diffNetwork(t, state, map[string]interface{}{
+			"name":             "terraform-isolated-no-cidr",
+			"network_offering": "DefaultIsolatedNetworkOfferingWithSourceNatService",
+			"zone":             "Sandbox-simulator",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d != nil && len(d.Attributes) > 0 {
+			t.Fatalf("expected empty diff, got %+v", d.Attributes)
+		}
+	})
+
+	t.Run("existing L2 network shows no drift", func(t *testing.T) {
+		state := &terraform.InstanceState{
+			ID: "net-2",
+			Attributes: map[string]string{
+				"id":                        "net-2",
+				"name":                      "terraform-l2-network",
+				"display_text":              "terraform-l2-network",
+				"type":                      "L2",
+				"cidr":                      "",
+				"gateway":                   "",
+				"ip6cidr":                   "",
+				"ip6gateway":                "",
+				"startip":                   "",
+				"endip":                     "",
+				"startipv6":                 "",
+				"endipv6":                   "",
+				"network_domain":            "cs1cloud.internal",
+				"network_offering":          "DefaultL2NetworkOffering",
+				"vpc_id":                    "",
+				"acl_id":                    "none",
+				"project":                   "",
+				"source_nat_ip":             "false",
+				"source_nat_ip_address":     "",
+				"source_nat_ip_id":          "",
+				"zone":                      "Sandbox-simulator",
+				"bypass_vlan_overlap_check": "false",
+				"tags.%":                    "0",
+			},
+		}
+		d, err := diffNetwork(t, state, map[string]interface{}{
+			"name":             "terraform-l2-network",
+			"type":             "L2",
+			"network_offering": "DefaultL2NetworkOffering",
+			"zone":             "Sandbox-simulator",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d != nil && len(d.Attributes) > 0 {
+			t.Fatalf("expected empty diff, got %+v", d.Attributes)
+		}
+	})
+}

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -12,14 +12,27 @@ Creates a network.
 
 ## Example Usage
 
-Basic usage:
+Basic L3 network usage:
 
 ```hcl
 resource "cloudstack_network" "default" {
   name             = "test-network"
+  type             = "L3"
   cidr             = "10.0.0.0/16"
   network_offering = "Default Network"
   zone             = "zone-1"
+}
+```
+
+L2 VLAN-only network usage:
+
+```hcl
+resource "cloudstack_network" "l2_network" {
+  name             = "l2-network"
+  type             = "L2"
+  network_offering = "L2 Network Offering"
+  zone             = "zone-1"
+  vlan             = 100
 }
 ```
 
@@ -31,8 +44,9 @@ The following arguments are supported:
 
 * `display_text` - (Optional) The display text of the network.
 
-* `cidr` - (Required) The CIDR block for the network. Changing this forces a new
-    resource to be created.
+* `type` - (Optional) The type of network. Valid values are "L2" for VLAN-only networks and "L3" for IP-based networks. Defaults to "L3".
+
+* `cidr` - (Optional) The CIDR block for the network. Required when `type` is "L3", not allowed when `type` is "L2". Changing this forces a new resource to be created.
 
 * `gateway` - (Optional) Gateway that will be provided to the instances in this
     network. Defaults to the first usable IP in the range.

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -12,13 +12,25 @@ Creates a network.
 
 ## Example Usage
 
-Basic usage:
+Basic L3 network usage:
 
 ```hcl
 resource "cloudstack_network" "default" {
   name             = "test-network"
+  type             = "L3"
   cidr             = "10.0.0.0/16"
   network_offering = "Default Network"
+  zone             = "zone-1"
+}
+```
+
+L2 VLAN-only network usage (no `cidr` required):
+
+```hcl
+resource "cloudstack_network" "l2_network" {
+  name             = "l2-network"
+  type             = "L2"
+  network_offering = "L2 Network Offering"
   zone             = "zone-1"
 }
 ```
@@ -64,8 +76,14 @@ The following arguments are supported:
 
 * `display_text` - (Optional) The display text of the network.
 
-* `cidr` - (Required) The CIDR block for the network. Changing this forces a new
-    resource to be created.
+* `type` - (Optional) The type of network. Valid values are "L2" for VLAN-only
+    networks and "L3" for IP-based (isolated/shared) networks. When not set, the
+    type is computed from the network created by CloudStack. Changing this
+    forces a new resource to be created.
+
+* `cidr` - (Optional) The CIDR block for the network. Required when `type` is
+    explicitly set to "L3" and not allowed when `type` is "L2". Changing this
+    forces a new resource to be created.
 
 * `gateway` - (Optional) Gateway that will be provided to the instances in this
     network. Defaults to the first usable IP in the range.


### PR DESCRIPTION
- Add 'type' field to cloudstack_network resource schema
- Make 'cidr' field conditionally required based on network type
- L2 networks: cidr not required, IP parameters skipped
- L3 networks: cidr required, maintains backward compatibility
- Add CustomizeDiff validation for proper type/cidr combinations
- Update parseCIDR function to handle L2 networks without cidr
- Update resource creation logic to skip IP config for L2 networks
- Update read function to detect and set network type
- Add comprehensive test coverage for L2 networks
- Update documentation with L2 and L3 usage examples

Fixes #214