### PR TITLE
Add support to import ACL rules by ACL id

### DIFF
--- a/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -38,6 +38,9 @@ func resourceCloudStackNetworkACLRule() *schema.Resource {
 		Read:   resourceCloudStackNetworkACLRuleRead,
 		Update: resourceCloudStackNetworkACLRuleUpdate,
 		Delete: resourceCloudStackNetworkACLRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudStackNetworkACLRuleImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"acl_id": {
@@ -713,4 +716,38 @@ func retryableACLCreationFunc(
 		}
 		return r, nil
 	}
+}
+
+func resourceCloudStackNetworkACLRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	aclID := d.Id()
+
+	log.Printf("[DEBUG] Attempting to import ACL list with ID: %s", aclID)
+	if aclExists, err := checkACLListExists(cs, aclID); err != nil {
+		return nil, fmt.Errorf("error checking ACL list existence: %v", err)
+	} else if !aclExists {
+		return nil, fmt.Errorf("ACL list with ID %s does not exist", aclID)
+	}
+
+	log.Printf("[DEBUG] Found ACL list with ID: %s", aclID)
+	d.Set("acl_id", aclID)
+	d.SetId(aclID)
+
+	log.Printf("[DEBUG] Setting managed=true for ACL list import")
+	d.Set("managed", true)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func checkACLListExists(cs *cloudstack.CloudStackClient, aclID string) (bool, error) {
+	log.Printf("[DEBUG] Checking if ACL list exists: %s", aclID)
+	_, count, err := cs.NetworkACL.GetNetworkACLListByID(aclID)
+	if err != nil {
+		log.Printf("[DEBUG] Error getting ACL list by ID: %v", err)
+		return false, err
+	}
+
+	log.Printf("[DEBUG] ACL list check result: count=%d", count)
+	return count > 0, nil
 }


### PR DESCRIPTION
1. create the resource configuration in the root module

resource "cloudstack_network_acl_rule" "customAclRules" {
}

2. execute:
```
terraform import cloudstack_network_acl_rule.customAclRules 6efef584-d405-41f7-92a0-a66625496c97
```

Where `6efef584-d405-41f7-92a0-a66625496c97` is the UUID of the ACL from which the rules need to be imported

3. Run `terraform show` and find the ACL rules now managed by terraform:

```
# cloudstack_network_acl_rule.customAclRules:
resource "cloudstack_network_acl_rule" "customAclRules" {
    acl_id  = "6efef584-d405-41f7-92a0-a66625496c97"
    id      = "6efef584-d405-41f7-92a0-a66625496c97"
    managed = true

    rule {
        action       = null
        cidr_list    = [
            "1d6aae62-e5f5-4a6a-ad17-dd5a4aee3e8c",
        ]
        description  = null
        icmp_code    = 0
        icmp_type    = 0
        ports        = []
        protocol     = "1d6aae62-e5f5-4a6a-ad17-dd5a4aee3e8c"
        rule_number  = 0
        traffic_type = null
        uuids        = {
            "1d6aae62-e5f5-4a6a-ad17-dd5a4aee3e8c" = "1d6aae62-e5f5-4a6a-ad17-dd5a4aee3e8c"
        }
    }
}
```

Logs that the resource is successfully imported:
```
cloudstack_network_acl_rule.customAclRules: Importing from ID "6efef584-d405-41f7-92a0-a66625496c97"...
2025-09-17T16:54:37.971-0400 [DEBUG] ReferenceTransformer: "data.cloudstack_template.centos" references: []
2025-09-17T16:54:37.972-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:37 [DEBUG] Attempting to import with ID: 6efef584-d405-41f7-92a0-a66625496c97, project: 
2025-09-17T16:54:37.972-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:37 [DEBUG] Checking if ACL list exists: 6efef584-d405-41f7-92a0-a66625496c97, project: 
data.cloudstack_template.centos: Reading...
2025-09-17T16:54:38.287-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:38 [DEBUG] ACL list check result: count=1
2025-09-17T16:54:38.287-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:38 [DEBUG] Found ACL list with ID: 6efef584-d405-41f7-92a0-a66625496c97
2025-09-17T16:54:38.287-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:38 [DEBUG] Setting managed=true for ACL list import
cloudstack_network_acl_rule.customAclRules: Import prepared!
  Prepared cloudstack_network_acl_rule for import
cloudstack_network_acl_rule.customAclRules: Refreshing state... [id=6efef584-d405-41f7-92a0-a66625496c97]
2025-09-17T16:54:38.306-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:38 [DEBUG] Selected template: CentOS 5.5(64-bit) no GUI (KVM)
2025-09-17T16:54:38.306-0400 [DEBUG] provider.terraform-provider-cloudstack: 2025/09/17 16:54:38 [ERROR] setting state: size: '' expected type 'string', got unconvertible type 'int64', value: '8589934592'
data.cloudstack_template.centos: Read complete after 0s [id=67c3a097-8416-11f0-9a72-1e001b000238]
2025-09-17T16:54:38.307-0400 [DEBUG] ReferenceTransformer: "cloudstack_instance.initial_vm" references: []
2025-09-17T16:54:38.650-0400 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2025-09-17T16:54:38.652-0400 [INFO]  provider: plugin process exited: plugin=/home/pdsilva/sb/terraform/local-providers/hashicorp.com/dev/cloudstack/1.0.0/linux_amd64/terraform-provider-cloudstack id=213630
2025-09-17T16:54:38.652-0400 [DEBUG] provider: plugin exited
2025-09-17T16:54:38.652-0400 [INFO]  Writing state output to:

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

```

Did the same for project level - works as expected.
