### PR TITLE
fix: Enhance network ACL rule creation & reading

### DIFF
--- a/cloudstack/resource_cloudstack_network_acl_rule.go
+++ b/cloudstack/resource_cloudstack_network_acl_rule.go
@@ -20,6 +20,7 @@
 package cloudstack
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -138,90 +140,118 @@ func resourceCloudStackNetworkACLRule() *schema.Resource {
 }
 
 func resourceCloudStackNetworkACLRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Entering resourceCloudStackNetworkACLRuleCreate with acl_id=%s", d.Get("acl_id").(string))
+
 	// Make sure all required parameters are there
 	if err := verifyNetworkACLParams(d); err != nil {
+		log.Printf("[ERROR] Failed parameter verification: %v", err)
 		return err
 	}
-
-	// We need to set this upfront in order to be able to save a partial state
-	d.SetId(d.Get("acl_id").(string))
 
 	// Create all rules that are configured
 	if nrs := d.Get("rule").(*schema.Set); nrs.Len() > 0 {
 		// Create an empty rule set to hold all newly created rules
 		rules := resourceCloudStackNetworkACLRule().Schema["rule"].ZeroValue().(*schema.Set)
 
+		log.Printf("[DEBUG] Processing %d rules", nrs.Len())
 		err := createNetworkACLRules(d, meta, rules, nrs)
-
-		// We need to update this first to preserve the correct state
-		d.Set("rule", rules)
-
 		if err != nil {
+			log.Printf("[ERROR] Failed to create network ACL rules: %v", err)
 			return err
 		}
+
+		// Set the resource ID only after successful creation
+		log.Printf("[DEBUG] Setting resource ID to acl_id=%s", d.Get("acl_id").(string))
+		d.SetId(d.Get("acl_id").(string))
+
+		// Update state with created rules
+		if err := d.Set("rule", rules); err != nil {
+			log.Printf("[ERROR] Failed to set rule attribute: %v", err)
+			return err
+		}
+	} else {
+		log.Printf("[DEBUG] No rules provided, setting ID to acl_id=%s", d.Get("acl_id").(string))
+		d.SetId(d.Get("acl_id").(string))
 	}
 
+	log.Printf("[DEBUG] Calling resourceCloudStackNetworkACLRuleRead")
 	return resourceCloudStackNetworkACLRuleRead(d, meta)
 }
 
 func createNetworkACLRules(d *schema.ResourceData, meta interface{}, rules *schema.Set, nrs *schema.Set) error {
+	log.Printf("[DEBUG] Creating %d network ACL rules", nrs.Len())
 	var errs *multierror.Error
 
 	var wg sync.WaitGroup
 	wg.Add(nrs.Len())
 
 	sem := make(chan struct{}, d.Get("parallelism").(int))
-	for _, rule := range nrs.List() {
+	for i, rule := range nrs.List() {
 		// Put in a tiny sleep here to avoid DoS'ing the API
 		time.Sleep(500 * time.Millisecond)
 
-		go func(rule map[string]interface{}) {
+		go func(rule map[string]interface{}, index int) {
 			defer wg.Done()
 			sem <- struct{}{}
 
+			log.Printf("[DEBUG] Creating rule #%d: %+v", index+1, rule)
+
 			// Create a single rule
 			err := createNetworkACLRule(d, meta, rule)
-
-			// If we have at least one UUID, we need to save the rule
-			if len(rule["uuids"].(map[string]interface{})) > 0 {
-				rules.Add(rule)
-			}
-
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				log.Printf("[ERROR] Failed to create rule #%d: %v", index+1, err)
+				errs = multierror.Append(errs, fmt.Errorf("rule #%d: %v", index+1, err))
+			} else if len(rule["uuids"].(map[string]interface{})) > 0 {
+				log.Printf("[DEBUG] Successfully created rule #%d, adding to rules set", index+1)
+				rules.Add(rule)
+			} else {
+				log.Printf("[WARN] Rule #%d created but has no UUIDs", index+1)
 			}
 
 			<-sem
-		}(rule.(map[string]interface{}))
+		}(rule.(map[string]interface{}), i)
 	}
 
 	wg.Wait()
 
-	return errs.ErrorOrNil()
+	if err := errs.ErrorOrNil(); err != nil {
+		log.Printf("[ERROR] Errors occurred while creating rules: %v", err)
+		return err
+	}
+
+	log.Printf("[DEBUG] Successfully created all rules")
+	return nil
 }
 
 func createNetworkACLRule(d *schema.ResourceData, meta interface{}, rule map[string]interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
 	uuids := rule["uuids"].(map[string]interface{})
+	log.Printf("[DEBUG] Creating network ACL rule with protocol=%s", rule["protocol"].(string))
 
 	// Make sure all required parameters are there
 	if err := verifyNetworkACLRuleParams(d, rule); err != nil {
+		log.Printf("[ERROR] Failed to verify rule parameters: %v", err)
 		return err
 	}
 
 	// Create a new parameter struct
 	p := cs.NetworkACL.NewCreateNetworkACLParams(rule["protocol"].(string))
+	log.Printf("[DEBUG] Initialized CreateNetworkACLParams")
 
 	// If a rule ID is specified, set it
 	if ruleNum, ok := rule["rule_number"].(int); ok && ruleNum > 0 {
 		p.SetNumber(ruleNum)
+		log.Printf("[DEBUG] Set rule_number=%d", ruleNum)
 	}
 
-	// Set the acl ID
-	p.SetAclid(d.Id())
+	// Set the acl ID from the configuration
+	aclID := d.Get("acl_id").(string)
+	p.SetAclid(aclID)
+	log.Printf("[DEBUG] Set aclid=%s", aclID)
 
 	// Set the action
 	p.SetAction(rule["action"].(string))
+	log.Printf("[DEBUG] Set action=%s", rule["action"].(string))
 
 	// Set the CIDR list
 	var cidrList []string
@@ -229,58 +259,87 @@ func createNetworkACLRule(d *schema.ResourceData, meta interface{}, rule map[str
 		cidrList = append(cidrList, cidr.(string))
 	}
 	p.SetCidrlist(cidrList)
+	log.Printf("[DEBUG] Set cidr_list=%v", cidrList)
 
 	// Set the traffic type
 	p.SetTraffictype(rule["traffic_type"].(string))
+	log.Printf("[DEBUG] Set traffic_type=%s", rule["traffic_type"].(string))
 
 	// Set the description
 	if desc, ok := rule["description"].(string); ok && desc != "" {
 		p.SetReason(desc)
+		log.Printf("[DEBUG] Set description=%s", desc)
 	}
 
 	// If the protocol is ICMP set the needed ICMP parameters
 	if rule["protocol"].(string) == "icmp" {
 		p.SetIcmptype(rule["icmp_type"].(int))
 		p.SetIcmpcode(rule["icmp_code"].(int))
+		log.Printf("[DEBUG] Set icmp_type=%d, icmp_code=%d", rule["icmp_type"].(int), rule["icmp_code"].(int))
 
 		r, err := Retry(4, retryableACLCreationFunc(cs, p))
 		if err != nil {
+			log.Printf("[ERROR] Failed to create ICMP rule: %v", err)
 			return err
 		}
-
 		uuids["icmp"] = r.(*cloudstack.CreateNetworkACLResponse).Id
 		rule["uuids"] = uuids
+		log.Printf("[DEBUG] Created ICMP rule with ID=%s", r.(*cloudstack.CreateNetworkACLResponse).Id)
 	}
 
 	// If the protocol is ALL set the needed parameters
 	if rule["protocol"].(string) == "all" {
 		r, err := Retry(4, retryableACLCreationFunc(cs, p))
 		if err != nil {
+			log.Printf("[ERROR] Failed to create ALL rule: %v", err)
 			return err
 		}
-
 		uuids["all"] = r.(*cloudstack.CreateNetworkACLResponse).Id
 		rule["uuids"] = uuids
+		log.Printf("[DEBUG] Created ALL rule with ID=%s", r.(*cloudstack.CreateNetworkACLResponse).Id)
 	}
 
-	// If protocol is TCP or UDP, loop through all ports
+	// If protocol is TCP or UDP, create the rule (with or without ports)
 	if rule["protocol"].(string) == "tcp" || rule["protocol"].(string) == "udp" {
-		if ps := rule["ports"].(*schema.Set); ps.Len() > 0 {
+		ps, ok := rule["ports"].(*schema.Set)
+		if !ok || ps == nil {
+			log.Printf("[DEBUG] No ports specified for TCP/UDP rule, creating rule for all ports")
+			ps = &schema.Set{F: schema.HashString}
+		}
 
-			// Create an empty schema.Set to hold all processed ports
-			ports := &schema.Set{F: schema.HashString}
+		// Create an empty schema.Set to hold all processed ports
+		ports := &schema.Set{F: schema.HashString}
+		log.Printf("[DEBUG] Processing %d ports for TCP/UDP rule", ps.Len())
 
+		if ps.Len() == 0 {
+			// Create a rule for all ports
+			r, err := Retry(4, retryableACLCreationFunc(cs, p))
+			if err != nil {
+				log.Printf("[ERROR] Failed to create TCP/UDP rule for all ports: %v", err)
+				return err
+			}
+			uuids["all_ports"] = r.(*cloudstack.CreateNetworkACLResponse).Id
+			rule["uuids"] = uuids
+			log.Printf("[DEBUG] Created TCP/UDP rule for all ports with ID=%s", r.(*cloudstack.CreateNetworkACLResponse).Id)
+		} else {
+			// Process specified ports
 			for _, port := range ps.List() {
 				if _, ok := uuids[port.(string)]; ok {
 					ports.Add(port)
 					rule["ports"] = ports
+					log.Printf("[DEBUG] Port %s already has UUID, skipping", port.(string))
 					continue
 				}
 
 				m := splitPorts.FindStringSubmatch(port.(string))
+				if m == nil {
+					log.Printf("[ERROR] Invalid port format: %s", port.(string))
+					return fmt.Errorf("%q is not a valid port value. Valid options are '80' or '80-90'", port.(string))
+				}
 
 				startPort, err := strconv.Atoi(m[1])
 				if err != nil {
+					log.Printf("[ERROR] Failed to parse start port %s: %v", m[1], err)
 					return err
 				}
 
@@ -288,32 +347,37 @@ func createNetworkACLRule(d *schema.ResourceData, meta interface{}, rule map[str
 				if m[2] != "" {
 					endPort, err = strconv.Atoi(m[2])
 					if err != nil {
+						log.Printf("[ERROR] Failed to parse end port %s: %v", m[2], err)
 						return err
 					}
 				}
 
 				p.SetStartport(startPort)
 				p.SetEndport(endPort)
+				log.Printf("[DEBUG] Set ports start=%d, end=%d", startPort, endPort)
 
 				r, err := Retry(4, retryableACLCreationFunc(cs, p))
 				if err != nil {
+					log.Printf("[ERROR] Failed to create TCP/UDP rule for port %s: %v", port.(string), err)
 					return err
 				}
 
 				ports.Add(port)
 				rule["ports"] = ports
-
 				uuids[port.(string)] = r.(*cloudstack.CreateNetworkACLResponse).Id
 				rule["uuids"] = uuids
+				log.Printf("[DEBUG] Created TCP/UDP rule for port %s with ID=%s", port.(string), r.(*cloudstack.CreateNetworkACLResponse).Id)
 			}
 		}
 	}
 
+	log.Printf("[DEBUG] Successfully created rule with uuids=%+v", uuids)
 	return nil
 }
 
 func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)
+	log.Printf("[DEBUG] Entering resourceCloudStackNetworkACLRuleRead with acl_id=%s", d.Id())
 
 	// First check if the ACL itself still exists
 	_, count, err := cs.NetworkACL.GetNetworkACLListByID(
@@ -322,23 +386,39 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 	)
 	if err != nil {
 		if count == 0 {
-			log.Printf(
-				"[DEBUG] Network ACL list %s does no longer exist", d.Id())
+			log.Printf("[DEBUG] Network ACL list %s does not exist", d.Id())
 			d.SetId("")
 			return nil
 		}
-
+		log.Printf("[ERROR] Failed to get ACL list by ID: %v", err)
 		return err
 	}
 
-	// Get all the rules from the running environment
+	// Get all the rules from the running environment with retries
 	p := cs.NetworkACL.NewListNetworkACLsParams()
 	p.SetAclid(d.Id())
 	p.SetListall(true)
 
-	l, err := cs.NetworkACL.ListNetworkACLs(p)
-	if err != nil {
-		return err
+	var l *cloudstack.ListNetworkACLsResponse
+	retryErr := retry.RetryContext(context.Background(), 30*time.Second, func() *retry.RetryError {
+		var err error
+		l, err = cs.NetworkACL.ListNetworkACLs(p)
+		if err != nil {
+			log.Printf("[DEBUG] Failed to list network ACL rules, retrying: %v", err)
+			return retry.RetryableError(err)
+		}
+		if l.Count == 0 {
+			log.Printf("[DEBUG] No network ACL rules found for ACL %s, retrying", d.Id())
+			return retry.RetryableError(fmt.Errorf("no network ACL rules found for ACL %s", d.Id()))
+		}
+		log.Printf("[DEBUG] Found %d network ACL rules for ACL %s", l.Count, d.Id())
+		return nil
+	})
+
+	if retryErr != nil {
+		log.Printf("[WARN] Network ACL rules for %s not found after retries", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	// Make a map of all the rules so we can easily find a rule
@@ -346,6 +426,7 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 	for _, r := range l.NetworkACLs {
 		ruleMap[r.Id] = r
 	}
+	log.Printf("[DEBUG] Loaded %d rules into ruleMap", len(ruleMap))
 
 	// Create an empty schema.Set to hold all rules
 	rules := resourceCloudStackNetworkACLRule().Schema["rule"].ZeroValue().(*schema.Set)
@@ -355,16 +436,19 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 		for _, rule := range rs.List() {
 			rule := rule.(map[string]interface{})
 			uuids := rule["uuids"].(map[string]interface{})
+			log.Printf("[DEBUG] Processing rule with protocol=%s, uuids=%+v", rule["protocol"].(string), uuids)
 
 			if rule["protocol"].(string) == "icmp" {
 				id, ok := uuids["icmp"]
 				if !ok {
+					log.Printf("[DEBUG] No ICMP UUID found, skipping rule")
 					continue
 				}
 
 				// Get the rule
 				r, ok := ruleMap[id.(string)]
 				if !ok {
+					log.Printf("[DEBUG] ICMP rule with ID %s not found, removing UUID", id.(string))
 					delete(uuids, "icmp")
 					continue
 				}
@@ -386,17 +470,20 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 				rule["traffic_type"] = strings.ToLower(r.Traffictype)
 				rule["cidr_list"] = cidrs
 				rules.Add(rule)
+				log.Printf("[DEBUG] Added ICMP rule to state: %+v", rule)
 			}
 
 			if rule["protocol"].(string) == "all" {
 				id, ok := uuids["all"]
 				if !ok {
+					log.Printf("[DEBUG] No ALL UUID found, skipping rule")
 					continue
 				}
 
 				// Get the rule
 				r, ok := ruleMap[id.(string)]
 				if !ok {
+					log.Printf("[DEBUG] ALL rule with ID %s not found, removing UUID", id.(string))
 					delete(uuids, "all")
 					continue
 				}
@@ -416,51 +503,64 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 				rule["traffic_type"] = strings.ToLower(r.Traffictype)
 				rule["cidr_list"] = cidrs
 				rules.Add(rule)
+				log.Printf("[DEBUG] Added ALL rule to state: %+v", rule)
 			}
 
-			// If protocol is tcp or udp, loop through all ports
 			if rule["protocol"].(string) == "tcp" || rule["protocol"].(string) == "udp" {
-				if ps := rule["ports"].(*schema.Set); ps.Len() > 0 {
+				ps, ok := rule["ports"].(*schema.Set)
+				if !ok || ps == nil {
+					log.Printf("[DEBUG] No ports specified for TCP/UDP rule, initializing empty set")
+					ps = &schema.Set{F: schema.HashString}
+				}
 
-					// Create an empty schema.Set to hold all ports
-					ports := &schema.Set{F: schema.HashString}
+				// Create an empty schema.Set to hold all ports
+				ports := &schema.Set{F: schema.HashString}
+				log.Printf("[DEBUG] Processing %d ports for TCP/UDP rule", ps.Len())
 
-					// Loop through all ports and retrieve their info
-					for _, port := range ps.List() {
-						id, ok := uuids[port.(string)]
-						if !ok {
-							continue
-						}
-
-						// Get the rule
-						r, ok := ruleMap[id.(string)]
-						if !ok {
-							delete(uuids, port.(string))
-							continue
-						}
-
-						// Delete the known rule so only unknown rules remain in the ruleMap
-						delete(ruleMap, id.(string))
-
-						// Create a set with all CIDR's
-						cidrs := &schema.Set{F: schema.HashString}
-						for _, cidr := range strings.Split(r.Cidrlist, ",") {
-							cidrs.Add(cidr)
-						}
-
-						// Update the values
-						rule["action"] = strings.ToLower(r.Action)
-						rule["protocol"] = r.Protocol
-						rule["traffic_type"] = strings.ToLower(r.Traffictype)
-						rule["cidr_list"] = cidrs
-						ports.Add(port)
+				// Loop through all ports and retrieve their info
+				for _, port := range ps.List() {
+					id, ok := uuids[port.(string)]
+					if !ok {
+						log.Printf("[DEBUG] No UUID for port %s, skipping", port.(string))
+						continue
 					}
 
-					// If there is at least one port found, add this rule to the rules set
-					if ports.Len() > 0 {
-						rule["ports"] = ports
-						rules.Add(rule)
+					// Get the rule
+					r, ok := ruleMap[id.(string)]
+					if !ok {
+						log.Printf("[DEBUG] TCP/UDP rule for port %s with ID %s not found, removing UUID", port.(string), id.(string))
+						delete(uuids, port.(string))
+						continue
 					}
+
+					// Delete the known rule so only unknown rules remain in the ruleMap
+					delete(ruleMap, id.(string))
+
+					// Create a set with all CIDR's
+					cidrs := &schema.Set{F: schema.HashString}
+					for _, cidr := range strings.Split(r.Cidrlist, ",") {
+						cidrs.Add(cidr)
+					}
+
+					// Update the values
+					rule["action"] = strings.ToLower(r.Action)
+					rule["protocol"] = r.Protocol
+					rule["traffic_type"] = strings.ToLower(r.Traffictype)
+					rule["cidr_list"] = cidrs
+					ports.Add(port)
+					log.Printf("[DEBUG] Added port %s to TCP/UDP rule", port.(string))
+				}
+
+				// If there is at least one port found, add this rule to the rules set
+				if ports.Len() > 0 {
+					rule["ports"] = ports
+					rules.Add(rule)
+					log.Printf("[DEBUG] Added TCP/UDP rule to state: %+v", rule)
+				} else {
+					// Add the rule even if no ports are specified, as ports are optional
+					rule["ports"] = ports
+					rules.Add(rule)
+					log.Printf("[DEBUG] Added TCP/UDP rule with no ports to state: %+v", rule)
 				}
 			}
 		}
@@ -484,15 +584,22 @@ func resourceCloudStackNetworkACLRuleRead(d *schema.ResourceData, meta interface
 
 			// Add the dummy rule to the rules set
 			rules.Add(rule)
+			log.Printf("[DEBUG] Added managed dummy rule for UUID %s", uuid)
 		}
 	}
 
 	if rules.Len() > 0 {
-		d.Set("rule", rules)
+		log.Printf("[DEBUG] Setting %d rules in state", rules.Len())
+		if err := d.Set("rule", rules); err != nil {
+			log.Printf("[ERROR] Failed to set rule attribute: %v", err)
+			return err
+		}
 	} else if !managed {
+		log.Printf("[DEBUG] No rules found and not managed, clearing ID")
 		d.SetId("")
 	}
 
+	log.Printf("[DEBUG] Completed resourceCloudStackNetworkACLRuleRead")
 	return nil
 }
 
@@ -647,10 +754,13 @@ func verifyNetworkACLParams(d *schema.ResourceData) error {
 }
 
 func verifyNetworkACLRuleParams(d *schema.ResourceData, rule map[string]interface{}) error {
+	log.Printf("[DEBUG] Verifying parameters for rule: %+v", rule)
+
 	if ruleNum, ok := rule["rule_number"]; ok && ruleNum != nil {
 		if number, ok := ruleNum.(int); ok && number != 0 {
 			// Validate only if rule_number is explicitly set (non-zero)
 			if number < 1 || number > 65535 {
+				log.Printf("[ERROR] Invalid rule_number: %d", number)
 				return fmt.Errorf(
 					"%q must be between %d and %d inclusive, got: %d", "rule_number", 1, 65535, number)
 			}
@@ -659,50 +769,59 @@ func verifyNetworkACLRuleParams(d *schema.ResourceData, rule map[string]interfac
 
 	action := rule["action"].(string)
 	if action != "allow" && action != "deny" {
+		log.Printf("[ERROR] Invalid action: %s", action)
 		return fmt.Errorf("Parameter action only accepts 'allow' or 'deny' as values")
 	}
 
 	protocol := rule["protocol"].(string)
+	log.Printf("[DEBUG] Validating protocol: %s", protocol)
 	switch protocol {
 	case "icmp":
 		if _, ok := rule["icmp_type"]; !ok {
+			log.Printf("[ERROR] Missing icmp_type for ICMP protocol")
 			return fmt.Errorf(
 				"Parameter icmp_type is a required parameter when using protocol 'icmp'")
 		}
 		if _, ok := rule["icmp_code"]; !ok {
+			log.Printf("[ERROR] Missing icmp_code for ICMP protocol")
 			return fmt.Errorf(
 				"Parameter icmp_code is a required parameter when using protocol 'icmp'")
 		}
 	case "all":
-		// No additional test are needed, so just leave this empty...
+		// No additional test are needed
+		log.Printf("[DEBUG] Protocol 'all' validated")
 	case "tcp", "udp":
 		if ports, ok := rule["ports"].(*schema.Set); ok {
+			log.Printf("[DEBUG] Found %d ports for TCP/UDP", ports.Len())
 			for _, port := range ports.List() {
 				m := splitPorts.FindStringSubmatch(port.(string))
 				if m == nil {
+					log.Printf("[ERROR] Invalid port format: %s", port.(string))
 					return fmt.Errorf(
 						"%q is not a valid port value. Valid options are '80' or '80-90'", port.(string))
 				}
 			}
 		} else {
-			return fmt.Errorf(
-				"Parameter ports is a required parameter when *not* using protocol 'icmp'")
+			log.Printf("[DEBUG] No ports specified for TCP/UDP, assuming empty set")
+			// Allow empty ports for TCP/UDP (your config has no ports)
 		}
 	default:
 		_, err := strconv.ParseInt(protocol, 0, 0)
 		if err != nil {
+			log.Printf("[ERROR] Invalid protocol: %s", protocol)
 			return fmt.Errorf(
-				"%q is not a valid protocol. Valid options are 'tcp', 'udp', "+
-					"'icmp', 'all' or a valid protocol number", protocol)
+				"%q is not a valid protocol. Valid options are 'tcp', 'udp', 'icmp', 'all' or a valid protocol number", protocol)
 		}
 	}
 
 	traffic := rule["traffic_type"].(string)
 	if traffic != "ingress" && traffic != "egress" {
+		log.Printf("[ERROR] Invalid traffic_type: %s", traffic)
 		return fmt.Errorf(
 			"Parameter traffic_type only accepts 'ingress' or 'egress' as values")
 	}
 
+	log.Printf("[DEBUG] Rule parameters verified successfully")
 	return nil
 }
 


### PR DESCRIPTION
    This commit addresses multiple issues in the `cloudstack_network_acl_rule` resource to improve reliability and compatibility with configurations lacking port specifications:

    1. **Fix `aclid` usage in `createNetworkACLRule`**:
       - Replaced `p.SetAclid(d.Id())` with `p.SetAclid(d.Get("acl_id").(string))` to use the configured `acl_id` instead of the unset resource ID during creation. This resolves CloudStack API error 431 (CSExceptionErrorCode: 9999) caused by an empty `aclid` value.

    2. **Support TCP/UDP rules without ports**: - Modified `createNetworkACLRule` to create rules for TCP/UDP protocols when no ports are specified, using a default "all ports" rule with a UUID stored as `all_ports`. This ensures compatibility with configs omitting the optional `ports` attribute. - Updated `resourceCloudStackNetworkACLRuleRead` to handle TCP/UDP rules with no ports, adding them to the state even if the `ports` set is empty.

    3. **Add retry logic for API consistency**:
       - Introduced retry logic in `resourceCloudStackNetworkACLRuleRead` using `retry.RetryContext` to handle eventual consistency in CloudStack's `ListNetworkACLs` API, retrying for up to 30 seconds if the API call fails or returns no rules.

    4. **Improve validation in `verifyNetworkACLRuleParams`**: - Relaxed validation to allow empty `ports` for TCP/UDP protocols, aligning with the schema where `ports` is optional. This prevents validation errors for configs without ports.

    5. **Enhance logging for debugging**:
       - Added detailed `[DEBUG]` and `[ERROR]` logs across `resourceCloudStackNetworkACLRuleCreate`, `createNetworkACLRules`, `createNetworkACLRule`, `resourceCloudStackNetworkACLRuleRead`, and `verifyNetworkACLRuleParams` to trace rule creation, validation, and API interactions.
       - Included rule indices and detailed error messages in `createNetworkACLRules` for better error reporting.

    6. **Defer `d.SetId` in `Create`**: - Moved `d.SetId(d.Get("acl_id").(string))` in `resourceCloudStackNetworkACLRuleCreate` to after successful rule creation to avoid premature state updates.

    These changes resolve the "Provider produced inconsistent result after apply: Root object was present, but now absent" error by ensuring rules are created correctly and consistently read from CloudStack. The fixes also improve robustness for multi-rule configurations and eventual consistency scenarios.