### PR TITLE
Add boot mode for instance

### DIFF
--- a/cloudstack/resource_cloudstack_instance.go
+++ b/cloudstack/resource_cloudstack_instance.go
@@ -188,6 +188,7 @@ func resourceCloudStackInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"Secure", "Legacy"}, true),
 				ForceNew:     true,
+				Description:  "The boot mode of the instance. Can only be specified when uefi is true. Valid options are 'Legacy' and 'Secure'.",
 			},
 
 			"start_vm": {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -104,6 +104,8 @@ The following arguments are supported:
 
 * `uefi` - (Optional) When set, will boot the instance in UEFI/Legacy mode (defaults false)
 
+* `boot_mode` - (Optional) The boot mode of the instance. Can only be specified when uefi is true. Valid options are 'Legacy' and 'Secure'.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Doesn't allow setting boot mode when uefi is false

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudstack_instance.initial_vm will be created
  + resource "cloudstack_instance" "initial_vm" {
      + boot_mode              = "Secure"
      + disk_offering          = (known after apply)
      + display_name           = (known after apply)
      + expunge                = true
      + group                  = (known after apply)
      + id                     = (known after apply)
      + ip_address             = (known after apply)
      + name                   = "initial-web-server"
      + network_id             = (known after apply)
      + override_disk_offering = (known after apply)
      + project                = (known after apply)
      + root_disk_size         = (known after apply)
      + service_offering       = "CKSMinimum"
      + start_vm               = true
      + tags                   = (known after apply)
      + template               = "ubuntu"
      + uefi                   = false
      + zone                   = "ref-trl-9688-k-Mol8-pearl-dsilva"
    }

  # cloudstack_network.vm_network will be created
  + resource "cloudstack_network" "vm_network" {
      + acl_id                = "none"
      + cidr                  = "10.0.10.0/24"
      + display_text          = "Isolated network for VMs"
      + endip                 = (known after apply)
      + gateway               = (known after apply)
      + id                    = (known after apply)
      + name                  = "vm-isolated-network"
      + network_domain        = (known after apply)
      + network_offering      = "DefaultIsolatedNetworkOfferingWithSourceNatService"
      + project               = (known after apply)
      + source_nat_ip_address = (known after apply)
      + source_nat_ip_id      = (known after apply)
      + startip               = (known after apply)
      + tags                  = (known after apply)
      + zone                  = "ref-trl-9688-k-Mol8-pearl-dsilva"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
cloudstack_network.vm_network: Creating...
cloudstack_network.vm_network: Creation complete after 2s [id=09d5f2af-f39a-4ba0-98aa-863e0bd8e993]
cloudstack_instance.initial_vm: Creating...
╷
│ Error: boot_mode can only be specified when uefi is true, got boot_mode=Secure with uefi=false
│ 
│   with cloudstack_instance.initial_vm,
│   on main.tf line 32, in resource "cloudstack_instance" "initial_vm":
│   32: resource "cloudstack_instance" "initial_vm" {

```


On setting UEFI to `true` and boot_mode to `secure` it successfully deploys the VM
```
$ terraform state show cloudstack_instance.initial_vm
# cloudstack_instance.initial_vm:
resource "cloudstack_instance" "initial_vm" {
    boot_mode        = "secure"
    disk_offering    = null
    display_name     = "initial-web-server"
    expunge          = true
    group            = null
    id               = "8f78aa48-c06d-43ba-bf07-35c8947eb436"
    ip_address       = "10.0.10.8"
    name             = "initial-web-server"
    network_id       = "5c1cf4a7-2c33-47f9-ad88-8360fe63fc93"
    project          = null
    root_disk_size   = 4
    service_offering = "CKSMinimum"
    start_vm         = true
    tags             = {}
    template         = "ubuntu"
    uefi             = true
    zone             = "ref-trl-9688-k-Mol8-pearl-dsilva"
}
```