### PR TITLE
Fix traffic type import due to incorrect parameter

### DIFF
--- a/cloudstack/resource_cloudstack_traffic_type.go
+++ b/cloudstack/resource_cloudstack_traffic_type.go
@@ -171,8 +171,29 @@ func resourceCloudStackTrafficTypeRead(d *schema.ResourceData, meta interface{})
 		d.Set("traffic_type", trafficType.Traffictype)
 	}
 
-	// Note: The TrafficType struct doesn't have fields for network labels or VLAN
-	// We'll need to rely on what we store in the state
+	if trafficType.Kvmnetworklabel != "" {
+		d.Set("kvm_network_label", trafficType.Kvmnetworklabel)
+	}
+
+	if trafficType.Vlan != "" {
+		d.Set("vlan", trafficType.Vlan)
+	}
+
+	if trafficType.Xennetworklabel != "" {
+		d.Set("xen_network_label", trafficType.Xennetworklabel)
+	}
+
+	if trafficType.Vmwarenetworklabel != "" {
+		d.Set("vmware_network_label", trafficType.Vmwarenetworklabel)
+	}
+
+	if trafficType.Hypervnetworklabel != "" {
+		d.Set("hyperv_network_label", trafficType.Hypervnetworklabel)
+	}
+
+	if trafficType.Ovm3networklabel != "" {
+		d.Set("ovm3_network_label", trafficType.Ovm3networklabel)
+	}
 
 	return nil
 }

--- a/cloudstack/resource_cloudstack_traffic_type.go
+++ b/cloudstack/resource_cloudstack_traffic_type.go
@@ -167,10 +167,8 @@ func resourceCloudStackTrafficTypeRead(d *schema.ResourceData, meta interface{})
 		return nil
 	}
 
-	// The TrafficType struct has a Name field which contains the traffic type
-	// But in some cases it might be empty, so we'll keep the original value from the state
-	if trafficType.Name != "" {
-		d.Set("traffic_type", trafficType.Name)
+	if trafficType.Traffictype != "" {
+		d.Set("traffic_type", trafficType.Traffictype)
 	}
 
 	// Note: The TrafficType struct doesn't have fields for network labels or VLAN
@@ -266,9 +264,9 @@ func resourceCloudStackTrafficTypeImport(d *schema.ResourceData, meta interface{
 				d.Set("physical_network_id", pn.Id)
 
 				// Set the type attribute - use the original value from the API call
-				// If the Name field is empty, use a default value based on the traffic type ID
-				if tt.Name != "" {
-					d.Set("traffic_type", tt.Name)
+				// If the Traffictype field is empty, use a default value based on the traffic type ID
+				if tt.Traffictype != "" {
+					d.Set("traffic_type", tt.Traffictype)
 				} else {
 					// Use a default value based on common traffic types
 					// This is a fallback and might not be accurate


### PR DESCRIPTION
This fix depends on :
https://github.com/apache/cloudstack/pull/11875 / https://github.com/apache/cloudstack/pull/8151
https://github.com/apache/cloudstack-go/pull/127

To test it - update the go.mod with the following:

```
replace github.com/apache/cloudstack-go/v2 => <path_to_local_clone_of_cloudstack_go checked out to the fix>
```

### Test performed

main.tf
```
resource "cloudstack_traffic_type" "management" {
  physical_network_id = "03144da8-ecc6-4830-9d63-cce2f8aa2156"
  traffic_type        = "Management"
  
  # Optional network labels - these will be set to defaults during import
  kvm_network_label     = "cloudbr0"
}

resource "cloudstack_traffic_type" "public" {
  physical_network_id = "81d12fe1-3e62-406e-85f3-fc0df51553a0"
  traffic_type = "Public"
  kvm_network_label = "cloudbr1"
}

resource "cloudstack_traffic_type" "guest" {
  physical_network_id = "81d12fe1-3e62-406e-85f3-fc0df51553a0"
  traffic_type = "Guest"
  kvm_network_label = "cloudbr1"
}


```
terraform imports

```
$ terraform import cloudstack_traffic_type.management df60cacc-a9eb-4e33-9a4e-84c8458ea076
cloudstack_traffic_type.management: Importing from ID "df60cacc-a9eb-4e33-9a4e-84c8458ea076"...
cloudstack_traffic_type.management: Import prepared!
  Prepared cloudstack_traffic_type for import
cloudstack_traffic_type.management: Refreshing state... [id=df60cacc-a9eb-4e33-9a4e-84c8458ea076]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ terraform import cloudstack_traffic_type.guest 20c3d446-0c87-4123-a399-0b56b00f9908
cloudstack_traffic_type.guest: Importing from ID "20c3d446-0c87-4123-a399-0b56b00f9908"...
cloudstack_traffic_type.guest: Import prepared!
  Prepared cloudstack_traffic_type for import
cloudstack_traffic_type.guest: Refreshing state... [id=20c3d446-0c87-4123-a399-0b56b00f9908]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.


$ terraform import cloudstack_traffic_type.public 51ca4720-1f6c-4044-ad98-87adc3f15ef4
cloudstack_traffic_type.public: Importing from ID "51ca4720-1f6c-4044-ad98-87adc3f15ef4"...
cloudstack_traffic_type.public: Import prepared!
  Prepared cloudstack_traffic_type for import
cloudstack_traffic_type.public: Refreshing state... [id=51ca4720-1f6c-4044-ad98-87adc3f15ef4]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.


```

terraform state: post import
```
$ terraform show 
# cloudstack_traffic_type.guest:
resource "cloudstack_traffic_type" "guest" {
    id                  = "20c3d446-0c87-4123-a399-0b56b00f9908"
    kvm_network_label   = "cloudbr0"
    physical_network_id = "81d12fe1-3e62-406e-85f3-fc0df51553a0"
    traffic_type        = "Guest"
    xen_network_label   = "xenbr0"
}

# cloudstack_traffic_type.management:
resource "cloudstack_traffic_type" "management" {
    id                  = "df60cacc-a9eb-4e33-9a4e-84c8458ea076"
    kvm_network_label   = "cloudbr0"
    physical_network_id = "03144da8-ecc6-4830-9d63-cce2f8aa2156"
    traffic_type        = "Management"
    xen_network_label   = "xenbr0"
}

# cloudstack_traffic_type.public:
resource "cloudstack_traffic_type" "public" {
    id                  = "51ca4720-1f6c-4044-ad98-87adc3f15ef4"
    kvm_network_label   = "cloudbr0"
    physical_network_id = "81d12fe1-3e62-406e-85f3-fc0df51553a0"
    traffic_type        = "Public"
    xen_network_label   = "xenbr0"
}
```
