### PR TITLE
deprecate cloudstack_service_offering

### DIFF
--- a/cloudstack/resource_cloudstack_service_offering.go
+++ b/cloudstack/resource_cloudstack_service_offering.go
@@ -150,6 +150,8 @@ func resourceCloudStackServiceOffering() *schema.Resource {
 				},
 			},
 		},
+		DeprecationMessage: "cloudstack_service_offering is deprecated and will be removed in a future release. Please use the following resources instead: " +
+			"cloudstack_service_offering_constrained, cloudstack_service_offering_unconstrained or cloudstack_service_offering_fixed.",
 	}
 }
 


### PR DESCRIPTION
This PR adds a message that `cloudstack_service_offering` is deprecate and might be removed in future releases. 

Resource is replaced by: https://github.com/apache/cloudstack-terraform-provider/pull/138

- cloudstack_service_offering_constrained
- cloudstack_service_offering_unconstrained
- cloudstack_service_offering_fixed


This is based on the discussion in this PR thread.: https://github.com/apache/cloudstack-terraform-provider/pull/252