### PR TITLE
feat: Update `resource_cloudstack_security_group` to allow `domainid` or `projectid`

### DIFF
--- a/cloudstack/resource_cloudstack_security_group_test.go
+++ b/cloudstack/resource_cloudstack_security_group_test.go
@@ -60,7 +60,7 @@ func TestAccCloudStackSecurityGroup_project(t *testing.T) {
 					testAccCheckCloudStackSecurityGroupExists(
 						"cloudstack_security_group.foo", &sg),
 					resource.TestCheckResourceAttrPair(
-						"cloudstack_security_group.foo", "project_id",
+						"cloudstack_security_group.foo", "projectid",
 						"cloudstack_project.test", "id"),
 				),
 			},
@@ -187,13 +187,20 @@ resource "cloudstack_project" "test" {
 resource "cloudstack_security_group" "foo" {
   name = "terraform-security-group-project"
   description = "terraform-security-group-project-text"
-  project_id = cloudstack_project.test.id
+  projectid = cloudstack_project.test.id
 }`
 
 const testAccCloudStackSecurityGroup_account = `
+data "cloudstack_domain" "root" {
+  filter {
+    name  = "name"
+    value = "ROOT"
+  }
+}
+
 resource "cloudstack_security_group" "foo" {
   name = "terraform-security-group-account"
-	description = "terraform-security-group-account-text"
-	account = "admin"
-	domain = "ROOT"
+  description = "terraform-security-group-account-text"
+  account = "admin"
+  domainid = data.cloudstack_domain.root.id
 }`

--- a/cloudstack/resource_cloudstack_security_group_test.go
+++ b/cloudstack/resource_cloudstack_security_group_test.go
@@ -47,6 +47,47 @@ func TestAccCloudStackSecurityGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudStackSecurityGroup_project(t *testing.T) {
+	var sg cloudstack.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackSecurityGroup_project,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackSecurityGroupExists(
+						"cloudstack_security_group.foo", &sg),
+					resource.TestCheckResourceAttrPair(
+						"cloudstack_security_group.foo", "project_id",
+						"cloudstack_project.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudStackSecurityGroup_account(t *testing.T) {
+	var sg cloudstack.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackSecurityGroup_account,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackSecurityGroupExists(
+						"cloudstack_security_group.foo", &sg),
+					resource.TestCheckResourceAttr(
+						"cloudstack_security_group.foo", "account", "admin"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudStackSecurityGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,4 +176,24 @@ const testAccCloudStackSecurityGroup_basic = `
 resource "cloudstack_security_group" "foo" {
   name = "terraform-security-group"
 	description = "terraform-security-group-text"
+}`
+
+const testAccCloudStackSecurityGroup_project = `
+resource "cloudstack_project" "test" {
+  name = "terraform-security-group-test-project"
+  displaytext = "Terraform Security Group Test Project"
+}
+
+resource "cloudstack_security_group" "foo" {
+  name = "terraform-security-group-project"
+  description = "terraform-security-group-project-text"
+  project_id = cloudstack_project.test.id
+}`
+
+const testAccCloudStackSecurityGroup_account = `
+resource "cloudstack_security_group" "foo" {
+  name = "terraform-security-group-account"
+	description = "terraform-security-group-account-text"
+	account = "admin"
+	domain = "ROOT"
 }`

--- a/cloudstack/resources.go
+++ b/cloudstack/resources.go
@@ -162,6 +162,19 @@ func setProjectid(p cloudstack.ProjectIDSetter, cs *cloudstack.CloudStackClient,
 	return nil
 }
 
+// If there is a domain supplied, we retrieve and set the domain id
+func setDomainid(p cloudstack.DomainIDSetter, cs *cloudstack.CloudStackClient, d *schema.ResourceData) error {
+	if domain, ok := d.GetOk("domain"); ok {
+		domainid, e := retrieveID(cs, "domain", domain.(string))
+		if e != nil {
+			return e.Error()
+		}
+		p.SetDomainid(domainid)
+	}
+
+	return nil
+}
+
 // importStatePassthrough is a generic importer with project support.
 func importStatePassthrough(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// Try to split the ID to extract the optional project name.

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -19,6 +19,32 @@ resource "cloudstack_security_group" "default" {
 }
 ```
 
+### With Account and Domain
+
+```hcl
+resource "cloudstack_security_group" "account_sg" {
+  name        = "allow_web"
+  description = "Allow access to HTTP and HTTPS"
+  account     = "my-account"
+  domain      = "example-domain"
+}
+```
+
+### With Project
+
+```hcl
+resource "cloudstack_project" "my_project" {
+  name        = "my-project"
+  displaytext = "My Project"
+}
+
+resource "cloudstack_security_group" "project_sg" {
+  name        = "allow_web"
+  description = "Allow access to HTTP and HTTPS"
+  project_id  = cloudstack_project.my_project.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -29,8 +55,16 @@ The following arguments are supported:
 * `description` - (Optional) The description of the security group. Changing
     this forces a new resource to be created.
 
-* `project` - (Optional) The name or ID of the project to create this security
+* `account` - (Optional) The account name to create the security group for.
+    Must be used with `domain`. Cannot be used with `project_id`. Changing this
+    forces a new resource to be created.
+
+* `domain` - (Optional) The name or ID of the domain to create this security
     group in. Changing this forces a new resource to be created.
+
+* `project_id` - (Optional) The ID of the project to create this security
+    group in. Cannot be used with `account`. Changing this forces a new
+    resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -22,11 +22,18 @@ resource "cloudstack_security_group" "default" {
 ### With Account and Domain
 
 ```hcl
+data "cloudstack_domain" "my_domain" {
+  filter {
+    name  = "name"
+    value = "ROOT"
+  }
+}
+
 resource "cloudstack_security_group" "account_sg" {
   name        = "allow_web"
   description = "Allow access to HTTP and HTTPS"
   account     = "my-account"
-  domain      = "example-domain"
+  domainid    = data.cloudstack_domain.my_domain.id
 }
 ```
 
@@ -41,7 +48,7 @@ resource "cloudstack_project" "my_project" {
 resource "cloudstack_security_group" "project_sg" {
   name        = "allow_web"
   description = "Allow access to HTTP and HTTPS"
-  project_id  = cloudstack_project.my_project.id
+  projectid   = cloudstack_project.my_project.id
 }
 ```
 
@@ -56,13 +63,13 @@ The following arguments are supported:
     this forces a new resource to be created.
 
 * `account` - (Optional) The account name to create the security group for.
-    Must be used with `domain`. Cannot be used with `project_id`. Changing this
+    Must be used with `domainid`. Cannot be used with `projectid`. Changing this
     forces a new resource to be created.
 
-* `domain` - (Optional) The name or ID of the domain to create this security
+* `domainid` - (Optional) The name or ID of the domain to create this security
     group in. Changing this forces a new resource to be created.
 
-* `project_id` - (Optional) The ID of the project to create this security
+* `projectid` - (Optional) The name or ID of the project to create this security
     group in. Cannot be used with `account`. Changing this forces a new
     resource to be created.
 


### PR DESCRIPTION
Update `resource_cloudstack_security_group` to allow `domainid` or `projectid`

https://cloudstack.apache.org/api/apidocs-4.21/apis/createSecurityGroup.html

This is breaking since I'm renaming `project` to `projectid` (just more descriptive as to what is expected in this field and matches the actual api call)

With the code:

```hcl
data "cloudstack_domain" "root" {
  filter {
    name  = "name"
    value = "ROOT"
  }
}

resource "cloudstack_security_group" "foo" {
  name        = "terraform-security-group-account"
  description = "terraform-security-group-account-text"
  account     = "admin"
  domainid    = "ROOT"
}

resource "cloudstack_security_group" "foo2" {
  name        = "terraform-security-group-project"
  description = "terraform-security-group-project-text"
  projectid   = "fdaa5a01-bc8c-4e50-a0ea-9135a1c54fb3"
}
```


```shell
12:15:41.534 STDOUT terraform: Terraform used the selected providers to generate the following execution
12:15:41.534 STDOUT terraform: plan. Resource actions are indicated with the following symbols:
12:15:41.535 STDOUT terraform:   + create
12:15:41.535 STDOUT terraform:   ~ update in-place
12:15:41.535 STDOUT terraform: Terraform will perform the following actions:
12:15:41.535 STDOUT terraform:   # cloudstack_security_group.foo will be created
12:15:41.535 STDOUT terraform:   + resource "cloudstack_security_group" "foo" {
12:15:41.535 STDOUT terraform:       + account     = "admin"
12:15:41.535 STDOUT terraform:       + description = "terraform-security-group-account-text"
12:15:41.535 STDOUT terraform:       + domainid    = "03ff694f-a2d5-11f0-95ca-52540047021e"
12:15:41.535 STDOUT terraform:       + id          = (known after apply)
12:15:41.535 STDOUT terraform:       + name        = "terraform-security-group-account"
12:15:41.535 STDOUT terraform:       + projectid   = (known after apply)
12:15:41.535 STDOUT terraform:     }
12:15:41.535 STDOUT terraform:   # cloudstack_security_group.foo2 will be created
12:15:41.535 STDOUT terraform:   + resource "cloudstack_security_group" "foo2" {
12:15:41.535 STDOUT terraform:       + description = "terraform-security-group-project-text"
12:15:41.535 STDOUT terraform:       + domainid    = (known after apply)
12:15:41.535 STDOUT terraform:       + id          = (known after apply)
12:15:41.535 STDOUT terraform:       + name        = "terraform-security-group-project"
12:15:41.535 STDOUT terraform:       + projectid   = "fdaa5a01-bc8c-4e50-a0ea-9135a1c54fb3"
12:15:41.535 STDOUT terraform:     }

12:15:57.912 STDOUT terraform: Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
