### PR TITLE
add support for vpc internal lb

### DIFF
--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -126,6 +126,7 @@ func Provider() *schema.Provider {
 			"cloudstack_ipaddress":                      resourceCloudStackIPAddress(),
 			"cloudstack_kubernetes_cluster":             resourceCloudStackKubernetesCluster(),
 			"cloudstack_kubernetes_version":             resourceCloudStackKubernetesVersion(),
+			"cloudstack_loadbalancer":                   resourceCloudStackLoadBalancer(),
 			"cloudstack_loadbalancer_rule":              resourceCloudStackLoadBalancerRule(),
 			"cloudstack_network":                        resourceCloudStackNetwork(),
 			"cloudstack_network_acl":                    resourceCloudStackNetworkACL(),

--- a/cloudstack/resource_cloudstack_loadbalancer.go
+++ b/cloudstack/resource_cloudstack_loadbalancer.go
@@ -1,0 +1,182 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCloudStackLoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudStackLoadBalancerCreate,
+		Read:   resourceCloudStackLoadBalancerRead,
+		Delete: resourceCloudStackLoadBalancerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"algorithm": {
+				Description: "load balancer algorithm (source, roundrobin, leastconn)",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"instanceport": {
+				Description: "the TCP port of the virtual machine where the network traffic will be load balanced to",
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"name": {
+				Description: "name of the load balancer",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"networkid": {
+				Description: "The guest network the load balancer will be created for",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"scheme": {
+				Description: "the load balancer scheme. Supported value in this release is Internal",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"sourceipaddressnetworkid": {
+				Description: "the network id of the source ip address",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"sourceport": {
+				Description: "the source port the network traffic will be load balanced from",
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"description": {
+				Description: "the description of the load balancer",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
+			"sourceipaddress": {
+				Description: "the source IP address the network traffic will be load balanced from",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
+			"virtualmachineids": {
+				Description: "the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)",
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudStackLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	p := cs.LoadBalancer.NewCreateLoadBalancerParams(
+		d.Get("algorithm").(string),
+		d.Get("instanceport").(int),
+		d.Get("name").(string),
+		d.Get("networkid").(string),
+		d.Get("scheme").(string),
+		d.Get("sourceipaddressnetworkid").(string),
+		d.Get("sourceport").(int),
+	)
+	if v, ok := d.GetOk("description"); ok {
+		p.SetDescription(v.(string))
+	}
+	if v, ok := d.GetOk("sourceipaddress"); ok {
+		p.SetSourceipaddress(v.(string))
+	}
+
+	r, err := cs.LoadBalancer.CreateLoadBalancer(p)
+	if err != nil {
+		return err
+	}
+
+	if v, ok := d.GetOk("virtualmachineids"); ok {
+		vmIds := v.([]interface{})
+		for _, vmId := range vmIds {
+			assignParams := cs.LoadBalancer.NewAssignToLoadBalancerRuleParams(r.Id)
+			assignParams.SetVirtualmachineids([]string{vmId.(string)})
+			_, err := cs.LoadBalancer.AssignToLoadBalancerRule(assignParams)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	d.SetId(r.Id)
+
+	return resourceCloudStackLoadBalancerRead(d, meta)
+}
+
+func resourceCloudStackLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	r, _, err := cs.LoadBalancer.GetLoadBalancerByID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("algorithm", r.Algorithm)
+	d.Set("name", r.Name)
+	d.Set("network_id", r.Networkid)
+	d.Set("sourceipaddressnetworkid", r.Sourceipaddressnetworkid)
+
+	var vmIds []string
+	for _, vm := range r.Loadbalancerinstance {
+		vmIds = append(vmIds, vm.Id)
+	}
+	d.Set("virtualmachineids", vmIds)
+
+	return nil
+}
+
+func resourceCloudStackLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	_, err := cs.LoadBalancer.DeleteLoadBalancer(cs.LoadBalancer.NewDeleteLoadBalancerParams(d.Id()))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cloudstack/resource_cloudstack_loadbalancer.go
+++ b/cloudstack/resource_cloudstack_loadbalancer.go
@@ -96,7 +96,7 @@ func resourceCloudStackLoadBalancer() *schema.Resource {
 
 			"virtualmachineids": {
 				Description: "the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				ForceNew:    true,
 				Elem: &schema.Schema{
@@ -132,11 +132,11 @@ func resourceCloudStackLoadBalancerCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("virtualmachineids"); ok {
-		vmIds := v.([]interface{})
+		vmIds := v.(*schema.Set).List()
 		for _, vmId := range vmIds {
-			assignParams := cs.LoadBalancer.NewAssignToLoadBalancerRuleParams(r.Id)
-			assignParams.SetVirtualmachineids([]string{vmId.(string)})
-			_, err := cs.LoadBalancer.AssignToLoadBalancerRule(assignParams)
+			p_update := cs.LoadBalancer.NewAssignToLoadBalancerRuleParams(r.Id)
+			p_update.SetVirtualmachineids([]string{vmId.(string)})
+			_, err := cs.LoadBalancer.AssignToLoadBalancerRule(p_update)
 			if err != nil {
 				return err
 			}

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_loadbalancer"
+sidebar_current: "docs-cloudstack-resource-loadbalancer"
+description: |-
+  Creates an internal load balancer.
+---
+
+# cloudstack_pod
+
+Creates an internal load balancer.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "cloudstack_loadbalancer" "example" {
+  algorithm                = "Source"
+  description              = "Example Load Balancer"
+  instanceport             = "8081"
+  name                     = "internal-lb-example"
+  networkid                = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
+  scheme                   = "Internal"
+  sourceipaddressnetworkid = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
+  sourceport               = "8081"
+  virtualmachineids        = [ "48600f99-d890-472c-bc1a-7379af22727c", "749485a1-4081-49cd-9668-1d160ac94488", "9bbf3c6d-c8b8-42e8-ab37-e4f60a71f61d" ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `algorithm` - (Required) load balancer algorithm (source, roundrobin, leastconn).
+* `description` - (Optional) the description of the load balancer.
+* `instanceport` - (Required) the TCP port of the virtual machine where the network traffic will be load balanced to.
+* `name` - (Required) name of the load balancer.
+* `networkid` - (Required) The guest network the load balancer will be created for.
+* `scheme` - (Required) the load balancer scheme. Supported value in this release is Internal.
+* `sourceipaddressnetworkid` - (Required) the network id of the source ip address.
+* `sourceport` - (Required) the source port the network traffic will be load balanced from.
+* `sourceipaddress` - (Optional) the source IP address the network traffic will be load balanced from.
+* `virtualmachineids` - (Optional) the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3).
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - the Load Balancer ID.
+
+
+
+## Import
+
+A pod can be imported; use `<LOADBALANCER ID>` as the import ID. For
+example:
+
+```shell
+terraform import cloudstack_loadbalancer.example eefce154-e759-45a4-989a-9a432792801b
+```

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Creates an internal load balancer.
 ---
 
-# cloudstack_pod
+# cloudstack_loadbalancer
 
 Creates an internal load balancer.
 
@@ -54,7 +54,7 @@ The following attributes are exported:
 
 ## Import
 
-A pod can be imported; use `<LOADBALANCER ID>` as the import ID. For
+A load balancer can be imported; use `<LOADBALANCER ID>` as the import ID. For
 example:
 
 ```shell


### PR DESCRIPTION
## Description
Add support for creating internal load balancer resources with the possibility to assign instances to the load balancer rule.

## Reason
This feature allows users to create an internal load balancer for a certain vpc tier and assign instances to it in one step using the terraform provider following IaC principles.

## References
- Documentation: https://docs.cloudstack.apache.org/en/latest/adminguide/networking_and_traffic.html#load-balancing-across-tiers
- API:
  - createLoadBalancer: https://cloudstack.apache.org/api/apidocs-4.22/apis/createLoadBalancer.html
  - assignToLoadBalancerRule: https://cloudstack.apache.org/api/apidocs-4.22/apis/assignToLoadBalancerRule.html

## Changes
Added `cloudstack_loadbalancer` resource to the terraform provider and the corresponding documentation page.
- modified `cloudstack/provider.go`
- added `cloudstack/resource_cloudstack_loadbalancer.go`
- added `website/docs/r/loadbalancer.html.markdown`

## Deployment test
### Code:
```hcl
resource "cloudstack_loadbalancer" "test" {
  algorithm                = "Source"
  instanceport             = "8081"
  name                     = "test3"
  networkid                = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
  scheme                   = "Internal"
  sourceipaddressnetworkid = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
  sourceport               = "8081"
  virtualmachineids        = [ "48600f99-d890-472c-bc1a-7379af22727c", "749485a1-4081-49cd-9668-1d160ac94488", "9bbf3c6d-c8b8-42e8-ab37-e4f60a71f61d" ]
}
```

### Terraform apply:
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # cloudstack_loadbalancer.test will be created
  + resource "cloudstack_loadbalancer" "test" {
      + algorithm                = "Source"
      + id                       = (known after apply)
      + instanceport             = 8081
      + name                     = "test3"
      + networkid                = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
      + scheme                   = "Internal"
      + sourceipaddressnetworkid = "0ae8fa84-c78e-441a-8628-917d276c7d5c"
      + sourceport               = 8081
      + virtualmachineids        = [
          + "48600f99-d890-472c-bc1a-7379af22727c",
          + "749485a1-4081-49cd-9668-1d160ac94488",
          + "9bbf3c6d-c8b8-42e8-ab37-e4f60a71f61d",
        ]
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

cloudstack_loadbalancer.test: Creating...
cloudstack_loadbalancer.test: Still creating... [10s elapsed]
cloudstack_loadbalancer.test: Still creating... [20s elapsed]
cloudstack_loadbalancer.test: Still creating... [30s elapsed]
cloudstack_loadbalancer.test: Creation complete after 31s [id=eefce154-e759-45a4-989a-9a432792801b]
```

### Verify using API:
```json
{
  "listloadbalancersresponse": {
    "count": 1,
    "loadbalancer": [
      {
        "id": "eefce154-e759-45a4-989a-9a432792801b",
        "name": "test3",
        "algorithm": "Source",
        "networkid": "0ae8fa84-c78e-441a-8628-917d276c7d5c",
        "sourceipaddress": "10.0.0.13",
        "sourceipaddressnetworkid": "0ae8fa84-c78e-441a-8628-917d276c7d5c",
        "projectid": "850c3f62-94f5-497f-91f6-2a736af09b58",
        "project": "Test",
        "domainid": "96b987c6-a9a8-11f0-b71e-6c92cf3489d0",
        "domain": "ROOT",
        "domainpath": "ROOT",
        "loadbalancerrule": [
          {
            "sourceport": 8081,
            "instanceport": 8081,
            "state": "Active"
          }
        ],
        "loadbalancerinstance": [
          {
            "id": "48600f99-d890-472c-bc1a-7379af22727c",
            "name": "i-14-1286-VM",
            "ipaddress": "10.0.0.12"
          },
          {
            "id": "749485a1-4081-49cd-9668-1d160ac94488",
            "name": "i-14-1282-VM",
            "ipaddress": "10.0.0.11"
          },
          {
            "id": "9bbf3c6d-c8b8-42e8-ab37-e4f60a71f61d",
            "name": "i-14-1283-VM",
            "ipaddress": "10.0.0.10"
          }
        ],
        "tags": [],
        "fordisplay": true
      }
    ]
  }
}
```