### PR TITLE
add option to configure destination cidr in egress firewall rules

### DIFF
--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -320,10 +320,17 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 				// Delete the known rule so only unknown rules remain in the ruleMap
 				delete(ruleMap, id.(string))
 
+				// Create a set with all CIDR's
+				cidrs := &schema.Set{F: schema.HashString}
+				for _, cidr := range strings.Split(r.Cidrlist, ",") {
+					cidrs.Add(cidr)
+				}
+
 				// Update the values
 				rule["protocol"] = r.Protocol
 				rule["icmp_type"] = r.Icmptype
 				rule["icmp_code"] = r.Icmpcode
+				rule["cidr_list"] = cidrs
 				rules.Add(rule)
 			}
 

--- a/cloudstack/resource_cloudstack_egress_firewall.go
+++ b/cloudstack/resource_cloudstack_egress_firewall.go
@@ -201,15 +201,6 @@ func createEgressFirewallRule(d *schema.ResourceData, meta interface{}, rule map
 		p.SetCidrlist(cidrList)
 	}
 
-	// Set the destination CIDR list
-	var destcidrList []string
-	if rs := rule["cidr_list"].(*schema.Set); rs.Len() > 0 {
-		for _, cidr := range rule["dest_cidr_list"].(*schema.Set).List() {
-			destcidrList = append(destcidrList, cidr.(string))
-		}
-		p.SetDestcidrlist(destcidrList)
-	}
-
 	// If the protocol is ICMP set the needed ICMP parameters
 	if rule["protocol"].(string) == "icmp" {
 		p.SetIcmptype(rule["icmp_type"].(int))
@@ -329,24 +320,10 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 				// Delete the known rule so only unknown rules remain in the ruleMap
 				delete(ruleMap, id.(string))
 
-				// Create a set with all CIDR's
-				cidrs := &schema.Set{F: schema.HashString}
-				for _, cidr := range strings.Split(r.Cidrlist, ",") {
-					cidrs.Add(cidr)
-				}
-
-				// Create a set with all destination CIDR's
-				destcidrs := &schema.Set{F: schema.HashString}
-				for _, cidr := range strings.Split(r.Destcidrlist, ",") {
-					destcidrs.Add(cidr)
-				}
-
 				// Update the values
 				rule["protocol"] = r.Protocol
 				rule["icmp_type"] = r.Icmptype
 				rule["icmp_code"] = r.Icmpcode
-				rule["cidr_list"] = cidrs
-				rule["dest_cidr_list"] = destcidrs
 				rules.Add(rule)
 			}
 
@@ -380,16 +357,9 @@ func resourceCloudStackEgressFirewallRead(d *schema.ResourceData, meta interface
 							cidrs.Add(cidr)
 						}
 
-						// Create a set with all destination CIDR's
-						destcidrs := &schema.Set{F: schema.HashString}
-						for _, cidr := range strings.Split(r.Destcidrlist, ",") {
-							destcidrs.Add(cidr)
-						}
-
 						// Update the values
 						rule["protocol"] = r.Protocol
 						rule["cidr_list"] = cidrs
-						rule["dest_cidr_list"] = destcidrs
 						ports.Add(port)
 					}
 

--- a/website/docs/r/egress_firewall.html.markdown
+++ b/website/docs/r/egress_firewall.html.markdown
@@ -17,9 +17,10 @@ resource "cloudstack_egress_firewall" "default" {
   network_id = "6eb22f91-7454-4107-89f4-36afcdf33021"
 
   rule {
-    cidr_list = ["10.0.0.0/8"]
-    protocol  = "tcp"
-    ports     = ["80", "1000-2000"]
+    cidr_list      = ["10.1.0.0/16"]
+    dest_cidr_list = ["10.2.0.0/16"]
+    protocol       = "tcp"
+    ports          = ["80", "1000-2000"]
   }
 }
 ```
@@ -43,7 +44,9 @@ The following arguments are supported:
 
 The `rule` block supports:
 
-* `cidr_list` - (Required) A CIDR list to allow access to the given ports.
+* `cidr_list` - (Required) the cidr list to forward traffic from.
+
+* `dest_cidr_list` - (Optional) the cidr list to forward traffic to.
 
 * `protocol` - (Required) The name of the protocol to allow. Valid options are:
     `tcp`, `udp` and `icmp`.


### PR DESCRIPTION
## Description
This PR introduces support for configuring a destination network in outgoing firewall rules, a feature introduced in [API v4.10](https://cloudstack.apache.org/api/apidocs-4.10/apis/createEgressFirewallRule.html). The change is backward-compatible and not a breaking change, allowing users to optionally specify `dest_cidr_list` in their configuration.

## References
API: https://cloudstack.apache.org/api/apidocs-4.22/apis/createEgressFirewallRule.html

## Changes
Added `dest_cidr_list` option to the rules block of `cloudstack_egress_firewall` and updated the documentation page accordingly.
- modified `cloudstack/resource_cloudstack_egress_firewall.go`
- modified `website/docs/r/egress_firewall.html.markdown`

<img height="400" alt="dest_cidr_empty" src="https://github.com/user-attachments/assets/10a622f8-71ac-4c19-8f9e-acf58a6a3097" />
<img height="400" alt="dest_cidr_filled" src="https://github.com/user-attachments/assets/3ca39ac4-ae01-473d-9d35-cd5da8517214" />
