### PR TITLE
Fix infinite update loop for optional zone fields

### DIFF
--- a/cloudstack/resource_cloudstack_zone.go
+++ b/cloudstack/resource_cloudstack_zone.go
@@ -57,6 +57,7 @@ func resourceCloudStackZone() *schema.Resource {
 				Description: "the second DNS for the Zone",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"domain": {
 				Description: "Network domain name for the networks in the zone",
@@ -74,6 +75,7 @@ func resourceCloudStackZone() *schema.Resource {
 				Description: "the guest CIDR address for the Zone",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"internal_dns1": {
 				Description: "the first internal DNS for the Zone",
@@ -84,16 +86,19 @@ func resourceCloudStackZone() *schema.Resource {
 				Description: "the second internal DNS for the Zone",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"ip6_dns1": {
 				Description: "the first DNS for IPv6 network in the Zone",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"ip6_dns2": {
 				Description: "the second DNS for IPv6 network in the Zone",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"local_storage_enabled": {
 				Description: "true if local storage offering enabled, false otherwise",


### PR DESCRIPTION
Add `Computed: true` to optional zone fields that are set by the Read function. This prevents Terraform from detecting false drift when these fields are not explicitly set in the configuration but have values returned by the CloudStack API.

Fields fixed:
- `guest_cidr_address`
- `dns2`
- `internal_dns2`
- `ip6_dns1`
- `ip6_dns2`

The issue occurred because these fields were Optional but not Computed. When a user removed a previously set value from their config, Terraform would:
1. Expect the field to be null (not in config)
2. Read a non-null value from the API
3. Detect drift and plan to remove it
4. Send an update with the field omitted
5. CloudStack would retain the old value (no explicit clear)
6. Loop back to step 2

With Optional + Computed, Terraform accepts API-provided values even when not explicitly set in the configuration, breaking the update loop.