### PR TITLE
Don't build and test EOL versions

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   CLOUDSTACK_API_URL: http://localhost:8080/client/api
-  CLOUDSTACK_VERSIONS: "['4.19.0.1', '4.19.1.3', '4.19.2.0', '4.19.3.0', '4.20.1.0']"
+  CLOUDSTACK_VERSIONS: "['4.20.2.0', '4.22.0.0']"
 
 jobs:
   prepare-matrix:
@@ -78,8 +78,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform-version:
-          - '1.11.*'
           - '1.12.*'
+          - '1.13.*'
+          - '1.14.*'
         cloudstack-version: ${{ fromJson(needs.prepare-matrix.outputs.cloudstack-versions) }}
 
   acceptance-opentofu:
@@ -116,8 +117,9 @@ jobs:
       fail-fast: false
       matrix:
         opentofu-version:
-          - '1.8.*'
           - '1.9.*'
+          - '1.10.*'
+          - '1.11.*'
         cloudstack-version: ${{ fromJson(needs.prepare-matrix.outputs.cloudstack-versions) }}
 
   all-jobs-passed: # Will succeed if it is skipped

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -48,9 +48,9 @@ jobs:
     needs: [prepare-matrix]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Configure Cloudstack v${{ matrix.cloudstack-version }}
@@ -58,7 +58,7 @@ jobs:
         id: setup-cloudstack
         with:
           cloudstack-version: ${{ matrix.cloudstack-version }}
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
@@ -88,9 +88,9 @@ jobs:
     needs: [prepare-matrix]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Configure Cloudstack v${{ matrix.cloudstack-version }}
@@ -98,7 +98,7 @@ jobs:
         id: setup-cloudstack
         with:
           cloudstack-version: ${{ matrix.cloudstack-version }}
-      - uses: opentofu/setup-opentofu@000eeb8522f0572907c393e8151076c205fdba1b # v1.0.6
+      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1.0.8
         with:
           tofu_version: ${{ matrix.opentofu-version }}
       - name: Run acceptance test

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ docker pull apache/cloudstack-simulator
 
 or pull it with a particular build tag
 
-docker pull apache/cloudstack-simulator:4.20.1.0
+docker pull apache/cloudstack-simulator:4.22.0.0
 
 docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator
 
 or
 
-docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.20.1.0
+docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.22.0.0
 ```
 
 When Docker started the container you can go to <http://localhost:8080/client> and login to the CloudStack UI as user `admin` with password `password`. It can take a few minutes for the container is fully ready, so you probably need to wait and refresh the page for a few minutes before the login page is shown.

--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ In order to run the full suite of Acceptance tests you will need to run the Clou
 ### Step 1: Start the CloudStack Simulator
 
 ```sh
-# Pull the simulator image (recommended versions: 4.20.1.0 or 4.23.0.0-SNAPSHOT)
-docker pull apache/cloudstack-simulator:4.20.1.0
+# Pull the simulator image (recommended versions: 4.20.2.0 or 4.23.0.0-SNAPSHOT)
+docker pull apache/cloudstack-simulator:4.20.2.0
 
 # Start the simulator container
-docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.20.1.0
+docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.20.2.0
 ```
 
-**Note:** Version 4.22.0.0 has a known bug with updating load balancer rules and is not recommended for testing.
+**Note:** Version 4.22.0.0 has a known bug with updating load balancer rules. CI currently tests against this version, but for local testing we recommend using 4.20.2.0 or 4.23.0.0-SNAPSHOT to avoid this issue.
 
 ### Step 2: Wait for Simulator to be Ready
 

--- a/README.md
+++ b/README.md
@@ -123,37 +123,51 @@ make test
 
 In order to run the full suite of Acceptance tests you will need to run the CloudStack Simulator. Please follow these steps to prepare an environment for running the Acceptance tests:
 
+### Step 1: Start the CloudStack Simulator
+
 ```sh
-docker pull apache/cloudstack-simulator
+# Pull the simulator image (recommended versions: 4.20.1.0 or 4.23.0.0-SNAPSHOT)
+docker pull apache/cloudstack-simulator:4.20.1.0
 
-or pull it with a particular build tag
-
-docker pull apache/cloudstack-simulator:4.22.0.0
-
-docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator
-
-or
-
-docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.22.0.0
+# Start the simulator container
+docker run --name simulator -p 8080:5050 -d apache/cloudstack-simulator:4.20.1.0
 ```
 
-When Docker started the container you can go to <http://localhost:8080/client> and login to the CloudStack UI as user `admin` with password `password`. It can take a few minutes for the container is fully ready, so you probably need to wait and refresh the page for a few minutes before the login page is shown.
+**Note:** Version 4.22.0.0 has a known bug with updating load balancer rules and is not recommended for testing.
 
-Once the login page is shown and you can login, you need to provision a simulated data-center:
+### Step 2: Wait for Simulator to be Ready
+
+When Docker starts the container, wait a few minutes for it to fully initialize. You can check if it's ready by visiting <http://localhost:8080/client> and logging in as user `admin` with password `password`. You may need to wait and refresh the page for a few minutes before the login page is shown.
+
+### Step 3: Deploy the Data Center (REQUIRED)
+
+**This step is critical!** Simply starting the simulator is not enough. You must run the data center deployment script to create the necessary CloudStack resources (zones, networks, service offerings, templates, etc.):
 
 ```sh
 docker exec -it simulator python /root/tools/marvin/marvin/deployDataCenter.py -i /root/setup/dev/advanced.cfg
 ```
 
-If you refresh the client or login again, you will now get passed the initial welcome screen and be able to go to your account details and retrieve the API key and secret. Export those together with the URL:
+This script creates the "Sandbox-simulator" zone and other resources that the acceptance tests expect. **Without this step, most tests will fail with "zone not found" errors.**
+
+**Note:** This deployment script takes approximately **2-3 minutes** to complete. Wait for it to finish before proceeding to the next step. You should see output like "====Deploy DC Successful=====" when it's done.
+
+### Step 4: Get API Credentials
+
+After deploying the data center, refresh the CloudStack UI and log in again. You will now be able to access your account details and retrieve the API key and secret. Export those together with the URL:
 
 ```sh
 export CLOUDSTACK_API_URL=http://localhost:8080/client/api
-export CLOUDSTACK_API_KEY=r_gszj7e0ttr_C6CP5QU_1IV82EIOtK4o_K9i_AltVztfO68wpXihKs2Tms6tCMDY4HDmbqHc-DtTamG5x112w
-export CLOUDSTACK_SECRET_KEY=tsfMDShFe94f4JkJfEh6_tZZ--w5jqEW7vGL2tkZGQgcdbnxNoq9fRmwAtU5MEGGXOrDlNA6tfvGK14fk_MB6w
+export CLOUDSTACK_API_KEY=<your-api-key-from-ui>
+export CLOUDSTACK_SECRET_KEY=<your-secret-key-from-ui>
 ```
 
-In order for all the tests to pass, you will need to create a new (empty) project in the UI called `terraform`. When the project is created you can run the Acceptance tests against the CloudStack Simulator by simply running:
+### Step 5: Create Required Resources
+
+In order for all the tests to pass, you will need to create a new (empty) project in the UI called `terraform`.
+
+### Step 6: Run the Tests
+
+When the project is created you can run the Acceptance tests against the CloudStack Simulator by simply running:
 
 ```sh
 make testacc

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -148,6 +148,8 @@ func testAccPreCheck(t *testing.T) {
 
 // getCloudStackVersion returns the CloudStack version from the API
 func getCloudStackVersion(t *testing.T) string {
+	t.Helper()
+
 	cfg := Config{
 		APIURL:      os.Getenv("CLOUDSTACK_API_URL"),
 		APIKey:      os.Getenv("CLOUDSTACK_API_KEY"),
@@ -157,15 +159,13 @@ func getCloudStackVersion(t *testing.T) string {
 	}
 	cs, err := cfg.NewClient()
 	if err != nil {
-		t.Logf("Failed to create CloudStack client: %v", err)
-		return ""
+		t.Fatalf("Failed to create CloudStack client: %v", err)
 	}
 
 	p := cs.Configuration.NewListCapabilitiesParams()
 	r, err := cs.Configuration.ListCapabilities(p)
 	if err != nil {
-		t.Logf("Failed to get CloudStack capabilities: %v", err)
-		return ""
+		t.Fatalf("Failed to get CloudStack capabilities: %v", err)
 	}
 
 	if r.Capabilities != nil {

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
@@ -146,8 +147,10 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-// getCloudStackVersion returns the CloudStack version from the API
-func getCloudStackVersion(t *testing.T) string {
+// newTestClient creates a CloudStack client from environment variables for use in test PreCheck functions.
+// This is needed because PreCheck functions run before the test framework configures the provider,
+// so testAccProvider.Meta() is nil at that point.
+func newTestClient(t *testing.T) *cloudstack.CloudStackClient {
 	t.Helper()
 	testAccPreCheck(t)
 
@@ -162,6 +165,13 @@ func getCloudStackVersion(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Failed to create CloudStack client: %v", err)
 	}
+	return cs
+}
+
+// getCloudStackVersion returns the CloudStack version from the API
+func getCloudStackVersion(t *testing.T) string {
+	t.Helper()
+	cs := newTestClient(t)
 
 	p := cs.Configuration.NewListCapabilitiesParams()
 	r, err := cs.Configuration.ListCapabilities(p)

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -145,3 +145,32 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("CLOUDSTACK_SECRET_KEY must be set for acceptance tests")
 	}
 }
+
+// getCloudStackVersion returns the CloudStack version from the API
+func getCloudStackVersion(t *testing.T) string {
+	cfg := Config{
+		APIURL:      os.Getenv("CLOUDSTACK_API_URL"),
+		APIKey:      os.Getenv("CLOUDSTACK_API_KEY"),
+		SecretKey:   os.Getenv("CLOUDSTACK_SECRET_KEY"),
+		HTTPGETOnly: true,
+		Timeout:     60,
+	}
+	cs, err := cfg.NewClient()
+	if err != nil {
+		t.Logf("Failed to create CloudStack client: %v", err)
+		return ""
+	}
+
+	p := cs.Configuration.NewListCapabilitiesParams()
+	r, err := cs.Configuration.ListCapabilities(p)
+	if err != nil {
+		t.Logf("Failed to get CloudStack capabilities: %v", err)
+		return ""
+	}
+
+	if r.Capabilities != nil {
+		return r.Capabilities.Cloudstackversion
+	}
+
+	return ""
+}

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -149,6 +149,7 @@ func testAccPreCheck(t *testing.T) {
 // getCloudStackVersion returns the CloudStack version from the API
 func getCloudStackVersion(t *testing.T) string {
 	t.Helper()
+	testAccPreCheck(t)
 
 	cfg := Config{
 		APIURL:      os.Getenv("CLOUDSTACK_API_URL"),

--- a/cloudstack/resource_cloudstack_cni_configuration.go
+++ b/cloudstack/resource_cloudstack_cni_configuration.go
@@ -55,6 +55,7 @@ func resourceCloudStackCniConfiguration() *schema.Resource {
 			"account": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "An optional account for the CNI configuration. Must be used with domain_id.",
 			},
@@ -62,6 +63,7 @@ func resourceCloudStackCniConfiguration() *schema.Resource {
 			"domain_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "An optional domain ID for the CNI configuration. If the account parameter is used, domain_id must also be used.",
 			},
@@ -69,6 +71,7 @@ func resourceCloudStackCniConfiguration() *schema.Resource {
 			"project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "An optional project for the CNI configuration",
 			},
@@ -188,18 +191,9 @@ func resourceCloudStackCniConfigurationRead(d *schema.ResourceData, meta interfa
 
 	d.Set("name", config.CniConfiguration[0].Name)
 	d.Set("cni_config", config.CniConfiguration[0].Userdata)
-
-	// Only set account and domain_id if they were originally provided by the user
-	// to avoid drift when CloudStack returns default values
-	if _, ok := d.GetOk("account"); ok {
-		d.Set("account", config.CniConfiguration[0].Account)
-	}
-	if _, ok := d.GetOk("domain_id"); ok {
-		d.Set("domain_id", config.CniConfiguration[0].Domainid)
-	}
-	if _, ok := d.GetOk("project_id"); ok {
-		d.Set("project_id", config.CniConfiguration[0].Projectid)
-	}
+	d.Set("account", config.CniConfiguration[0].Account)
+	d.Set("domain_id", config.CniConfiguration[0].Domainid)
+	d.Set("project_id", config.CniConfiguration[0].Projectid)
 
 	if config.CniConfiguration[0].Params != "" {
 		paramsList := strings.Split(config.CniConfiguration[0].Params, ",")

--- a/cloudstack/resource_cloudstack_cni_configuration.go
+++ b/cloudstack/resource_cloudstack_cni_configuration.go
@@ -188,9 +188,18 @@ func resourceCloudStackCniConfigurationRead(d *schema.ResourceData, meta interfa
 
 	d.Set("name", config.CniConfiguration[0].Name)
 	d.Set("cni_config", config.CniConfiguration[0].Userdata)
-	d.Set("account", config.CniConfiguration[0].Account)
-	d.Set("domain_id", config.CniConfiguration[0].Domainid)
-	d.Set("project_id", config.CniConfiguration[0].Projectid)
+
+	// Only set account and domain_id if they were originally provided by the user
+	// to avoid drift when CloudStack returns default values
+	if _, ok := d.GetOk("account"); ok {
+		d.Set("account", config.CniConfiguration[0].Account)
+	}
+	if _, ok := d.GetOk("domain_id"); ok {
+		d.Set("domain_id", config.CniConfiguration[0].Domainid)
+	}
+	if _, ok := d.GetOk("project_id"); ok {
+		d.Set("project_id", config.CniConfiguration[0].Projectid)
+	}
 
 	if config.CniConfiguration[0].Params != "" {
 		paramsList := strings.Split(config.CniConfiguration[0].Params, ",")

--- a/cloudstack/resource_cloudstack_cni_configuration_test.go
+++ b/cloudstack/resource_cloudstack_cni_configuration_test.go
@@ -21,7 +21,6 @@ package cloudstack
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
@@ -143,24 +142,11 @@ resource "cloudstack_cni_configuration" "foo" {
 `
 
 func testAccPreCheckCniSupport(t *testing.T) {
-	testAccPreCheck(t)
-
-	// Create a CloudStack client to check if CNI is supported
-	cfg := Config{
-		APIURL:      os.Getenv("CLOUDSTACK_API_URL"),
-		APIKey:      os.Getenv("CLOUDSTACK_API_KEY"),
-		SecretKey:   os.Getenv("CLOUDSTACK_SECRET_KEY"),
-		HTTPGETOnly: true,
-		Timeout:     60,
-	}
-	cs, err := cfg.NewClient()
-	if err != nil {
-		t.Fatalf("Failed to create CloudStack client: %v", err)
-	}
+	cs := newTestClient(t)
 
 	// Try to list CNI configurations to check if the feature is available
 	p := cs.Configuration.NewListCniConfigurationParams()
-	_, err = cs.Configuration.ListCniConfiguration(p)
+	_, err := cs.Configuration.ListCniConfiguration(p)
 	if err != nil {
 		t.Skipf("CNI configuration not supported in this CloudStack version (requires 4.21.0+): %v", err)
 	}

--- a/cloudstack/resource_cloudstack_cni_configuration_test.go
+++ b/cloudstack/resource_cloudstack_cni_configuration_test.go
@@ -21,6 +21,7 @@ package cloudstack
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
@@ -142,11 +143,24 @@ resource "cloudstack_cni_configuration" "foo" {
 `
 
 func testAccPreCheckCniSupport(t *testing.T) {
-	cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+	testAccPreCheck(t)
+
+	// Create a CloudStack client to check if CNI is supported
+	cfg := Config{
+		APIURL:      os.Getenv("CLOUDSTACK_API_URL"),
+		APIKey:      os.Getenv("CLOUDSTACK_API_KEY"),
+		SecretKey:   os.Getenv("CLOUDSTACK_SECRET_KEY"),
+		HTTPGETOnly: true,
+		Timeout:     60,
+	}
+	cs, err := cfg.NewClient()
+	if err != nil {
+		t.Fatalf("Failed to create CloudStack client: %v", err)
+	}
 
 	// Try to list CNI configurations to check if the feature is available
 	p := cs.Configuration.NewListCniConfigurationParams()
-	_, err := cs.Configuration.ListCniConfiguration(p)
+	_, err = cs.Configuration.ListCniConfiguration(p)
 	if err != nil {
 		t.Skipf("CNI configuration not supported in this CloudStack version (requires 4.21.0+): %v", err)
 	}

--- a/cloudstack/resource_cloudstack_loadbalancer_rule.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule.go
@@ -369,7 +369,7 @@ func resourceCloudStackLoadBalancerRuleUpdate(d *schema.ResourceData, meta inter
 		_, err := cs.LoadBalancer.UpdateLoadBalancerRule(p)
 		if err != nil {
 			return fmt.Errorf(
-				"Error updating load balancer rule %s", name)
+				"Error updating load balancer rule %s: %s", name, err)
 		}
 	}
 

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -57,7 +57,6 @@ func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
 	// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
 	// that causes "530 Internal Server Error" when updating load balancer rules.
 	// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
-	testAccPreCheck(t)
 	version := getCloudStackVersion(t)
 	if version == "4.22.0.0" {
 		t.Skip("Skipping TestAccCloudStackLoadBalancerRule_update on CloudStack 4.22.0.0 due to known simulator bug (Error 530: Internal Server Error)")

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -57,7 +57,6 @@ func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
 	// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
 	// that causes "530 Internal Server Error" when updating load balancer rules.
 	// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
-	// See: https://github.com/apache/cloudstack/issues/XXXXX (if applicable)
 	testAccPreCheck(t)
 	version := getCloudStackVersion(t)
 	if version == "4.22.0.0" {

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -54,6 +54,15 @@ func TestAccCloudStackLoadBalancerRule_basic(t *testing.T) {
 }
 
 func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
+	// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
+	// that causes "530 Internal Server Error" when updating load balancer rules.
+	// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
+	// See: https://github.com/apache/cloudstack/issues/XXXXX (if applicable)
+	version := getCloudStackVersion(t)
+	if version == "4.22.0.0" {
+		t.Skip("Skipping TestAccCloudStackLoadBalancerRule_update on CloudStack 4.22.0.0 due to known simulator bug (Error 530: Internal Server Error)")
+	}
+
 	var id string
 
 	resource.Test(t, resource.TestCase{

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -58,7 +58,6 @@ func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
 			// that causes "530 Internal Server Error" when updating load balancer rules.
 			// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -54,18 +54,19 @@ func TestAccCloudStackLoadBalancerRule_basic(t *testing.T) {
 }
 
 func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
-	// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
-	// that causes "530 Internal Server Error" when updating load balancer rules.
-	// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
-	version := getCloudStackVersion(t)
-	if version == "4.22.0.0" {
-		t.Skip("Skipping TestAccCloudStackLoadBalancerRule_update on CloudStack 4.22.0.0 due to known simulator bug (Error 530: Internal Server Error)")
-	}
-
 	var id string
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			// Skip this test on CloudStack 4.22.0.0 due to a known simulator bug
+			// that causes "530 Internal Server Error" when updating load balancer rules.
+			// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
+			version := getCloudStackVersion(t)
+			if version == "4.22.0.0" {
+				t.Skip("Skipping TestAccCloudStackLoadBalancerRule_update on CloudStack 4.22.0.0 due to known simulator bug (Error 530: Internal Server Error)")
+			}
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudStackLoadBalancerRuleDestroy,
 		Steps: []resource.TestStep{

--- a/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
+++ b/cloudstack/resource_cloudstack_loadbalancer_rule_test.go
@@ -58,6 +58,7 @@ func TestAccCloudStackLoadBalancerRule_update(t *testing.T) {
 	// that causes "530 Internal Server Error" when updating load balancer rules.
 	// This bug does not exist in 4.20.1.0, 4.22.1.0+, or 4.23.0.0+.
 	// See: https://github.com/apache/cloudstack/issues/XXXXX (if applicable)
+	testAccPreCheck(t)
 	version := getCloudStackVersion(t)
 	if version == "4.22.0.0" {
 		t.Skip("Skipping TestAccCloudStackLoadBalancerRule_update on CloudStack 4.22.0.0 due to known simulator bug (Error 530: Internal Server Error)")

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -81,7 +81,7 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 	// Only set DiskOfferingId if it was already set in the state (i.e., user explicitly provided it)
 	// When using disk_offering block, CloudStack creates an internal disk offering and returns its ID,
 	// but we should not populate disk_offering_id in that case to avoid drift
-	if cs.Diskofferingid != "" && !state.DiskOfferingId.IsNull() {
+	if cs.Diskofferingid != "" && !state.DiskOfferingId.IsNull() && !state.DiskOfferingId.IsUnknown() {
 		state.DiskOfferingId = types.StringValue(cs.Diskofferingid)
 	}
 	if cs.Displaytext != "" {

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -78,7 +78,10 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 	if cs.Deploymentplanner != "" {
 		state.DeploymentPlanner = types.StringValue(cs.Deploymentplanner)
 	}
-	if cs.Diskofferingid != "" {
+	// Only set DiskOfferingId if it was already set in the state (i.e., user explicitly provided it)
+	// When using disk_offering block, CloudStack creates an internal disk offering and returns its ID,
+	// but we should not populate disk_offering_id in that case to avoid drift
+	if cs.Diskofferingid != "" && !state.DiskOfferingId.IsNull() {
 		state.DiskOfferingId = types.StringValue(cs.Diskofferingid)
 	}
 	if cs.Displaytext != "" {


### PR DESCRIPTION
There's no reason to build and test EOL versions of Cloudstack, OpenTofu, and Terraform. Also recent supported versions were being excluded.

This PR will also corrects test failures in newer versions and updates documentation to be more explicit in how to properly run the acceptance tests.