### PR TITLE
fix: make cidr optional for L2 network creation

### DIFF
--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -75,6 +75,7 @@ func resourceCloudStackNetwork() *schema.Resource {
 			"cidr": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -74,7 +74,7 @@ func resourceCloudStackNetwork() *schema.Resource {
 
 			"cidr": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -190,23 +190,25 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	m, err := parseCIDR(d, no.Specifyipranges)
-	if err != nil {
-		return err
-	}
+	if _, ok := d.GetOk("cidr"); ok {
+		m, err := parseCIDR(d, no.Specifyipranges)
+		if err != nil {
+			return err
+		}
 
-	// Set the needed IP config
-	p.SetGateway(m["gateway"])
-	p.SetNetmask(m["netmask"])
+		// Set the needed IP config
+		p.SetGateway(m["gateway"])
+		p.SetNetmask(m["netmask"])
 
-	// Only set the start IP if we have one
-	if startip, ok := m["startip"]; ok {
-		p.SetStartip(startip)
-	}
+		// Only set the start IP if we have one
+		if startip, ok := m["startip"]; ok {
+			p.SetStartip(startip)
+		}
 
-	// Only set the end IP if we have one
-	if endip, ok := m["endip"]; ok {
-		p.SetEndip(endip)
+		// Only set the end IP if we have one
+		if endip, ok := m["endip"]; ok {
+			p.SetEndip(endip)
+		}
 	}
 
 	// Set the network domain if we have one

--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -80,24 +80,27 @@ func resourceCloudStackNetwork() *schema.Resource {
 			},
 
 			"gateway": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"cidr"},
 			},
 
 			"startip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"cidr"},
 			},
 
 			"endip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"cidr"},
 			},
 
 			"network_domain": {
@@ -185,13 +188,13 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		p.SetDisplaytext(name)
 	}
 
-	// Get the network offering to check if it supports specifying IP ranges
-	no, _, err := cs.NetworkOffering.GetNetworkOfferingByID(networkofferingid)
-	if err != nil {
-		return err
-	}
-
 	if _, ok := d.GetOk("cidr"); ok {
+		// Get the network offering to check if it supports specifying IP ranges
+		no, _, err := cs.NetworkOffering.GetNetworkOfferingByID(networkofferingid)
+		if err != nil {
+			return err
+		}
+
 		m, err := parseCIDR(d, no.Specifyipranges)
 		if err != nil {
 			return err

--- a/cloudstack/resource_cloudstack_network_test.go
+++ b/cloudstack/resource_cloudstack_network_test.go
@@ -404,3 +404,32 @@ resource "cloudstack_network" "l2" {
   network_offering = "DefaultL2NetworkOffering"
   zone             = "Sandbox-simulator"
 }`
+
+func TestAccCloudStackNetwork_isolatedNoCidr(t *testing.T) {
+	var network cloudstack.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackNetwork_isolatedNoCidr,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackNetworkExists(
+						"cloudstack_network.isolated_no_cidr", &network),
+					resource.TestCheckResourceAttrSet(
+						"cloudstack_network.isolated_no_cidr", "cidr"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackNetwork_isolatedNoCidr = `
+resource "cloudstack_network" "isolated_no_cidr" {
+  name             = "terraform-isolated-no-cidr"
+  display_text     = "terraform-isolated-no-cidr"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  zone             = "Sandbox-simulator"
+}`

--- a/cloudstack/resource_cloudstack_network_test.go
+++ b/cloudstack/resource_cloudstack_network_test.go
@@ -377,3 +377,30 @@ resource "cloudstack_network" "foo" {
   acl_id = cloudstack_network_acl.bar.id
   zone = cloudstack_vpc.foo.zone
 }`
+
+func TestAccCloudStackNetwork_l2NoCidr(t *testing.T) {
+	var network cloudstack.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackNetwork_l2NoCidr,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackNetworkExists(
+						"cloudstack_network.l2", &network),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackNetwork_l2NoCidr = `
+resource "cloudstack_network" "l2" {
+  name             = "terraform-l2-network"
+  display_text     = "terraform-l2-network"
+  network_offering = "DefaultL2NetworkOffering"
+  zone             = "Sandbox-simulator"
+}`


### PR DESCRIPTION
The `cidr` field was marked as `Required` in the Terraform provider's schema for `cloudstack_network`, but the CloudStack `createNetwork` API only requires `name`, `networkOfferingId`, and `zoneId`. `gateway` and `netmask` are optional and unnecessary for L2 networks. 

This change makes `cidr` optional and conditionally applies the CIDR/gateway/netmask logic only when a CIDR is provided. 

An acceptance test has been added to verify L2 network creation without CIDR.
