### PR TITLE
Fix UserData not being found when added to a project

### DIFF
--- a/cloudstack/resource_cloudstack_user_data.go
+++ b/cloudstack/resource_cloudstack_user_data.go
@@ -21,6 +21,7 @@ package cloudstack
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
@@ -125,9 +126,19 @@ func resourceCloudStackUserDataRead(d *schema.ResourceData, meta interface{}) er
 	p := cs.User.NewListUserDataParams()
 	p.SetId(id)
 
+	if v, ok := d.GetOk("project_id"); ok {
+		p.SetProjectid(v.(string))
+	}
+
 	userdata, err := cs.User.ListUserData(p)
 	if err != nil {
 		return fmt.Errorf("Error retrieving user data with ID %s: %s", id, err)
+	}
+
+	if len(userdata.UserData) == 0 {
+		log.Printf("[DEBUG] User data %s no longer exists", id)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", userdata.UserData[0].Name)


### PR DESCRIPTION
# Description
When a user data resource is nested in a particular project using project_id, a global search will not find that particular user data.

If for some reason (as the case before),the userdata list command succeeds but doesn't contain any user data itself, throw an error for that.

# Reproduce bug
```tf
resource "cloudstack_project" "test-project" {
  name = "test-project"
}

resource "cloudstack_user_data" "test-userdata" {
  name = "cloudinit-test"
  userdata = base64encode(file("../some-cloudinit.yaml"))
  project_id = cloudstack_project.test-project.id
}
```