### PR TITLE
Support requesting a specific IP address in cloudstack_ipaddress

### DIFF
--- a/cloudstack/resource_cloudstack_ipaddress.go
+++ b/cloudstack/resource_cloudstack_ipaddress.go
@@ -69,7 +69,9 @@ func resourceCloudStackIPAddress() *schema.Resource {
 
 			"ip_address": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"is_source_nat": {
@@ -123,6 +125,10 @@ func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{})
 	// If there is a project supplied, we retrieve and set the project id
 	if err := setProjectid(p, cs, d); err != nil {
 		return err
+	}
+
+	if ipaddress, ok := d.GetOk("ip_address"); ok {
+		p.SetIpaddress(ipaddress.(string))
 	}
 
 	// Associate a new IP address

--- a/cloudstack/resource_cloudstack_ipaddress_test.go
+++ b/cloudstack/resource_cloudstack_ipaddress_test.go
@@ -82,7 +82,7 @@ func TestAccCloudStackIPAddress_specificIP(t *testing.T) {
 					testAccCheckCloudStackIPAddressExists(
 						"cloudstack_ipaddress.foo", &ipaddr),
 					resource.TestCheckResourceAttr(
-						"cloudstack_ipaddress.foo", "ip_address", "10.2.2.10"),
+						"cloudstack_ipaddress.foo", "ip_address", "10.2.2.11"),
 				),
 			},
 		},
@@ -208,7 +208,7 @@ resource "cloudstack_vlan_ip_range" "foo" {
   gateway              = "10.2.2.1"
   netmask              = "255.255.255.0"
   start_ip             = "10.2.2.10"
-  end_ip               = "10.2.2.10"
+  end_ip               = "10.2.2.11"
 }
 
 resource "cloudstack_network" "foo" {
@@ -222,7 +222,7 @@ resource "cloudstack_network" "foo" {
 
 resource "cloudstack_ipaddress" "foo" {
   network_id = cloudstack_network.foo.id
-  ip_address = cloudstack_vlan_ip_range.foo.start_ip
+  ip_address = cloudstack_vlan_ip_range.foo.end_ip
 }`
 
 const testAccCloudStackIPAddress_vpcid_with_network_id = `

--- a/cloudstack/resource_cloudstack_ipaddress_test.go
+++ b/cloudstack/resource_cloudstack_ipaddress_test.go
@@ -68,6 +68,27 @@ func TestAccCloudStackIPAddress_vpc(t *testing.T) {
 	})
 }
 
+func TestAccCloudStackIPAddress_specificIP(t *testing.T) {
+	var ipaddr cloudstack.PublicIpAddress
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackIPAddressDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackIPAddress_specificIP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackIPAddressExists(
+						"cloudstack_ipaddress.foo", &ipaddr),
+					resource.TestCheckResourceAttr(
+						"cloudstack_ipaddress.foo", "ip_address", "10.2.2.10"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudStackIPAddress_vpcid_with_network_id(t *testing.T) {
 
 	regex := regexp.MustCompile("set only network_id or vpc_id")
@@ -162,6 +183,46 @@ resource "cloudstack_vpc" "foo" {
 resource "cloudstack_ipaddress" "foo" {
   vpc_id = cloudstack_vpc.foo.id
   zone = cloudstack_vpc.foo.zone
+}`
+
+const testAccCloudStackIPAddress_specificIP = `
+data "cloudstack_zone" "zone" {
+  filter {
+    name  = "name"
+    value = "Sandbox-simulator"
+  }
+}
+
+data "cloudstack_physical_network" "pn" {
+  filter {
+    name  = "zone_name"
+    value = "Sandbox-simulator"
+  }
+}
+
+resource "cloudstack_vlan_ip_range" "foo" {
+  physical_network_id = data.cloudstack_physical_network.pn.id
+  zone_id              = data.cloudstack_zone.zone.id
+  for_virtual_network  = true
+  vlan                 = "vlan://456"
+  gateway              = "10.2.2.1"
+  netmask              = "255.255.255.0"
+  start_ip             = "10.2.2.10"
+  end_ip               = "10.2.2.10"
+}
+
+resource "cloudstack_network" "foo" {
+  name = "terraform-network"
+  display_text = "terraform-network"
+  cidr = "10.1.1.0/24"
+  network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+  source_nat_ip = true
+  zone = "Sandbox-simulator"
+}
+
+resource "cloudstack_ipaddress" "foo" {
+  network_id = cloudstack_network.foo.id
+  ip_address = cloudstack_vlan_ip_range.foo.start_ip
 }`
 
 const testAccCloudStackIPAddress_vpcid_with_network_id = `

--- a/website/docs/r/ipaddress.html.markdown
+++ b/website/docs/r/ipaddress.html.markdown
@@ -37,6 +37,11 @@ The following arguments are supported:
 * `project` - (Optional) The name or ID of the project to deploy this
     instance to. Changing this forces a new resource to be created.
 
+* `ip_address` - (Optional) A specific IP address to acquire from the available
+    pool (e.g. from a `cloudstack_vlan_ip_range` dedicated to an account). If
+    not set, CloudStack auto-selects the next free address. Changing this
+    forces a new resource to be created.
+
 *NOTE: `network_id` and/or `zone` should have a value when `is_portable` is `false`!*
 *NOTE: Either `network_id` or `vpc_id` should have a value when `is_portable` is `true`!*
 


### PR DESCRIPTION
## Summary

`cloudstack_ipaddress` currently always lets CloudStack auto-select the next
free IP — there's no way to request a specific address. This blocks a common
pattern: an operator dedicates an intranet VLAN/IP range to an account, and
the tenant needs to acquire one *particular* address from it (e.g. because
firewall rules, DNS, or routing on the corporate side are already provisioned
for that exact IP).

The CloudStack API (`associateIpAddress`) already accepts an optional
`ipaddress` parameter; the provider never called it.

Fixes #291

## Changes

* `ip_address` changes from `Computed`-only to `Optional + Computed + ForceNew`.
  There's no CloudStack API to change an IP association in place, so a change
  to `ip_address` correctly triggers destroy+recreate.
* `resourceCloudStackIPAddressCreate` passes the value through to
  `AssociateIpAddressParams.SetIpaddress` when set.
* No changes to `Read`/`Delete` — the allocated address was already read back
  from the API response.
* New acceptance test, `TestAccCloudStackIPAddress_specificIP`, requesting a
  specific address from a dedicated `cloudstack_vlan_ip_range` so the
  assertion is deterministic (the shared default pool can't guarantee a given
  address is free).
* Documented the new argument in `website/docs/r/ipaddress.html.markdown`.

## Backward compatibility

Since `ip_address` was `Computed`-only before this change, no existing
configuration could have set it — Terraform rejects a config value for a
`Computed`-only attribute at validate time. The schema change is purely
additive; existing state with `ip_address` populated shows no diff.

## Testing

Verified against a simulator

* All pre-existing `cloudstack_ipaddress` acceptance tests pass unchanged
  (`_basic`, `_vpc`, `_vpcid_with_network_id`).
* New `_specificIP` test passes.
* Downstream consumers unaffected: `data_source_cloudstack_ipaddress`,
  `cloudstack_loadbalancer_rule` (all 5 variants), `cloudstack_static_nat`.
* Idempotent: `terraform plan`/`apply` with `ip_address` set and unchanged
  produces no diff and performs no actions; same when `ip_address` is
  omitted from config against existing state.
* Requesting an address already in use, or one outside any configured range,
  both fail clearly with `CloudStack API error 533: Insufficient address
  capacity` — no CloudStack-side ambiguity to handle.
* Changing `ip_address` correctly triggers `ForceNew`, scoped to only the
  `cloudstack_ipaddress` resource (the associated network is untouched).
* Manually verified (not yet covered by the automated test):
  `vpc_id` + `ip_address`, and `is_portable = true` + `ip_address` — both work
  correctly and are idempotent.