### PR TITLE
Add tags and import support to service offerings; fix zone_ids handling

### DIFF
--- a/cloudstack/service_offering_constrained_resource.go
+++ b/cloudstack/service_offering_constrained_resource.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
@@ -286,6 +287,10 @@ func (r *serviceOfferingConstrainedResource) Delete(ctx context.Context, req res
 		)
 		return
 	}
+}
+
+func (r *serviceOfferingConstrainedResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *serviceOfferingConstrainedResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/cloudstack/service_offering_constrained_resource.go
+++ b/cloudstack/service_offering_constrained_resource.go
@@ -111,7 +111,7 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 	// common params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
-	plan.applyLegacyTagsAlias(params)
+	plan.applyTags(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_constrained_resource.go
+++ b/cloudstack/service_offering_constrained_resource.go
@@ -111,6 +111,7 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 	// common params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
+	plan.applyLegacyTagsAlias(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_constrained_resource_test.go
+++ b/cloudstack/service_offering_constrained_resource_test.go
@@ -37,6 +37,11 @@ func TestAccServiceOfferingConstrained(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "cloudstack_service_offering_constrained.constrained1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccServiceOfferingCustomConstrained1ZoneAll,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.constrained1", "name", "constrained1"),

--- a/cloudstack/service_offering_fixed_resource.go
+++ b/cloudstack/service_offering_fixed_resource.go
@@ -96,7 +96,7 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 	// cloudstack params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
-	plan.applyLegacyTagsAlias(params)
+	plan.applyTags(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_fixed_resource.go
+++ b/cloudstack/service_offering_fixed_resource.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
@@ -226,6 +227,10 @@ func (r *serviceOfferingFixedResource) Delete(ctx context.Context, req resource.
 		)
 		return
 	}
+}
+
+func (r *serviceOfferingFixedResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *serviceOfferingFixedResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/cloudstack/service_offering_fixed_resource.go
+++ b/cloudstack/service_offering_fixed_resource.go
@@ -96,6 +96,7 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 	// cloudstack params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
+	plan.applyLegacyTagsAlias(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_fixed_resource_test.go
+++ b/cloudstack/service_offering_fixed_resource_test.go
@@ -37,6 +37,11 @@ func TestAccServiceOfferingFixed(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "cloudstack_service_offering_fixed.fixed1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccServiceOfferingFixed2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.fixed2", "name", "fixed2"),

--- a/cloudstack/service_offering_models.go
+++ b/cloudstack/service_offering_models.go
@@ -55,7 +55,6 @@ type serviceOfferingCommonResourceModel struct {
 	NetworkRate                      types.Int32  `tfsdk:"network_rate"`
 	OfferHa                          types.Bool   `tfsdk:"offer_ha"`
 	Tags                             types.String `tfsdk:"tags"`
-	ZoneId                           types.Set    `tfsdk:"zone_id"`
 	ZoneIds                          types.Set    `tfsdk:"zone_ids"`
 	ServiceOfferingDiskQosHypervisor types.Object `tfsdk:"disk_hypervisor"`
 	ServiceOfferingDiskOffering      types.Object `tfsdk:"disk_offering"`

--- a/cloudstack/service_offering_models.go
+++ b/cloudstack/service_offering_models.go
@@ -54,6 +54,8 @@ type serviceOfferingCommonResourceModel struct {
 	Name                             types.String `tfsdk:"name"`
 	NetworkRate                      types.Int32  `tfsdk:"network_rate"`
 	OfferHa                          types.Bool   `tfsdk:"offer_ha"`
+	Tags                             types.String `tfsdk:"tags"`
+	ZoneId                           types.Set    `tfsdk:"zone_id"`
 	ZoneIds                          types.Set    `tfsdk:"zone_ids"`
 	ServiceOfferingDiskQosHypervisor types.Object `tfsdk:"disk_hypervisor"`
 	ServiceOfferingDiskOffering      types.Object `tfsdk:"disk_offering"`

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -108,6 +108,15 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 			},
 			Default: booldefault.StaticBool(false),
 		},
+		"tags": schema.StringAttribute{
+			Description: "Legacy alias for storage tags",
+			Optional:    true,
+		},
+		"zone_id": schema.SetAttribute{
+			Description: "Legacy alias for zone_ids",
+			Optional:    true,
+			ElementType: types.StringType,
+		},
 		"zone_ids": schema.SetAttribute{
 			Description: "The ID of the zone(s)",
 			Optional:    true,

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -109,13 +109,8 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 			Default: booldefault.StaticBool(false),
 		},
 		"tags": schema.StringAttribute{
-			Description: "Legacy alias for storage tags",
+			Description: "The tags for the service offering",
 			Optional:    true,
-		},
-		"zone_id": schema.SetAttribute{
-			Description: "Legacy alias for zone_ids",
-			Optional:    true,
-			ElementType: types.StringType,
 		},
 		"zone_ids": schema.SetAttribute{
 			Description: "The ID of the zone(s)",

--- a/cloudstack/service_offering_unconstrained_resource.go
+++ b/cloudstack/service_offering_unconstrained_resource.go
@@ -73,6 +73,7 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 	// cloudstack params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
+	plan.applyLegacyTagsAlias(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_unconstrained_resource.go
+++ b/cloudstack/service_offering_unconstrained_resource.go
@@ -73,7 +73,7 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 	// cloudstack params
 	params := r.client.ServiceOffering.NewCreateServiceOfferingParams(plan.DisplayText.ValueString(), plan.Name.ValueString())
 	plan.commonCreateParams(ctx, params)
-	plan.applyLegacyTagsAlias(params)
+	plan.applyTags(params)
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)

--- a/cloudstack/service_offering_unconstrained_resource.go
+++ b/cloudstack/service_offering_unconstrained_resource.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -180,6 +181,10 @@ func (r *serviceOfferingUnconstrainedResource) Delete(ctx context.Context, req r
 		)
 		return
 	}
+}
+
+func (r *serviceOfferingUnconstrainedResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *serviceOfferingUnconstrainedResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/cloudstack/service_offering_unconstrained_resource_test.go
+++ b/cloudstack/service_offering_unconstrained_resource_test.go
@@ -37,6 +37,11 @@ func TestAccServiceOfferingUnconstrained(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "cloudstack_service_offering_unconstrained.unconstrained1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccServiceOfferingUnconstrained2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.unconstrained2", "name", "unconstrained2"),

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -44,9 +44,8 @@ func (state *serviceOfferingCommonResourceModel) commonUpdate(ctx context.Contex
 	if cs.Zoneid != "" && cs.Zoneid != "all" {
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
-	} else {
-		state.ZoneIds = types.SetNull(types.StringType)
 	}
+	// else: preserve prior state value (null or []) — both mean "all zones"
 }
 
 func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.Context, p *cloudstack.UpdateServiceOfferingParams) *cloudstack.UpdateServiceOfferingParams {
@@ -109,9 +108,8 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 	if cs.Zoneid != "" && cs.Zoneid != "all" {
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
-	} else {
-		state.ZoneIds = types.SetNull(types.StringType)
 	}
+	// else: preserve prior state value (null or []) — both mean "all zones"
 
 	state.DynamicScalingEnabled = types.BoolValue(cs.Dynamicscalingenabled)
 	state.IsVolatile = types.BoolValue(cs.Isvolatile)

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -45,8 +45,7 @@ func (state *serviceOfferingCommonResourceModel) commonUpdate(ctx context.Contex
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
 	} else {
-		z, _ := types.SetValueFrom(ctx, types.StringType, []string{})
-		state.ZoneIds = z
+		state.ZoneIds = types.SetNull(types.StringType)
 	}
 }
 
@@ -111,8 +110,7 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
 	} else {
-		z, _ := types.SetValueFrom(ctx, types.StringType, []string{})
-		state.ZoneIds = z
+		state.ZoneIds = types.SetNull(types.StringType)
 	}
 
 	state.DynamicScalingEnabled = types.BoolValue(cs.Dynamicscalingenabled)

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -53,7 +53,9 @@ func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.C
 		p.SetDisplaytext(plan.DisplayText.ValueString())
 	}
 	if !plan.DomainIds.IsNull() {
-		p.SetDomainid(plan.DomainIds.String())
+		domainIDs := make([]string, len(plan.DomainIds.Elements()))
+		plan.DomainIds.ElementsAs(ctx, &domainIDs, false)
+		p.SetDomainid(strings.Join(domainIDs, ","))
 	}
 	if !plan.HostTags.IsNull() {
 		p.SetHosttags(plan.HostTags.ValueString())
@@ -63,7 +65,9 @@ func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.C
 	}
 	zoneIDs := plan.ZoneIds
 	if !zoneIDs.IsNull() && len(zoneIDs.Elements()) > 0 {
-		p.SetZoneid(zoneIDs.String())
+		zoneIDSlice := make([]string, len(zoneIDs.Elements()))
+		zoneIDs.ElementsAs(ctx, &zoneIDSlice, false)
+		p.SetZoneid(strings.Join(zoneIDSlice, ","))
 	} else {
 		p.SetZoneid("all")
 	}

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -41,10 +41,12 @@ func (state *serviceOfferingCommonResourceModel) commonUpdate(ctx context.Contex
 	if cs.Name != "" {
 		state.Name = types.StringValue(cs.Name)
 	}
-	if cs.Zoneid != "" {
+	if cs.Zoneid != "" && cs.Zoneid != "all" {
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
-		state.ZoneId = z
+	} else {
+		z, _ := types.SetValueFrom(ctx, types.StringType, []string{})
+		state.ZoneIds = z
 	}
 }
 
@@ -105,10 +107,12 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 	if cs.Networkrate > 0 {
 		state.NetworkRate = types.Int32Value(int32(cs.Networkrate))
 	}
-	if cs.Zoneid != "" {
+	if cs.Zoneid != "" && cs.Zoneid != "all" {
 		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
 		state.ZoneIds = z
-		state.ZoneId = z
+	} else {
+		z, _ := types.SetValueFrom(ctx, types.StringType, []string{})
+		state.ZoneIds = z
 	}
 
 	state.DynamicScalingEnabled = types.BoolValue(cs.Dynamicscalingenabled)

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -62,9 +62,6 @@ func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.C
 		p.SetName(plan.Name.ValueString())
 	}
 	zoneIDs := plan.ZoneIds
-	if zoneIDs.IsNull() || len(zoneIDs.Elements()) == 0 {
-		zoneIDs = plan.ZoneId
-	}
 	if !zoneIDs.IsNull() && len(zoneIDs.Elements()) > 0 {
 		p.SetZoneid(zoneIDs.String())
 	} else {
@@ -214,9 +211,6 @@ func (plan *serviceOfferingCommonResourceModel) commonCreateParams(ctx context.C
 		p.SetOfferha(plan.OfferHa.ValueBool())
 	}
 	zoneIDs := plan.ZoneIds
-	if zoneIDs.IsNull() || len(zoneIDs.Elements()) == 0 {
-		zoneIDs = plan.ZoneId
-	}
 	if !zoneIDs.IsNull() {
 		zoneIds := make([]string, len(zoneIDs.Elements()))
 		zoneIDs.ElementsAs(ctx, &zoneIds, false)
@@ -274,7 +268,7 @@ func (plan *ServiceOfferingDiskOffering) commonCreateParams(ctx context.Context,
 
 }
 
-func (plan *serviceOfferingCommonResourceModel) applyLegacyTagsAlias(p *cloudstack.CreateServiceOfferingParams) {
+func (plan *serviceOfferingCommonResourceModel) applyTags(p *cloudstack.CreateServiceOfferingParams) {
 	if !plan.Tags.IsNull() {
 		p.SetTags(plan.Tags.ValueString())
 	}

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -42,7 +42,9 @@ func (state *serviceOfferingCommonResourceModel) commonUpdate(ctx context.Contex
 		state.Name = types.StringValue(cs.Name)
 	}
 	if cs.Zoneid != "" {
-		state.ZoneIds, _ = types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
+		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
+		state.ZoneIds = z
+		state.ZoneId = z
 	}
 }
 
@@ -59,8 +61,12 @@ func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.C
 	if !plan.Name.IsNull() {
 		p.SetName(plan.Name.ValueString())
 	}
-	if !plan.ZoneIds.IsNull() && len(plan.ZoneIds.Elements()) > 0 {
-		p.SetZoneid(plan.ZoneIds.String())
+	zoneIDs := plan.ZoneIds
+	if zoneIDs.IsNull() || len(zoneIDs.Elements()) == 0 {
+		zoneIDs = plan.ZoneId
+	}
+	if !zoneIDs.IsNull() && len(zoneIDs.Elements()) > 0 {
+		p.SetZoneid(zoneIDs.String())
 	} else {
 		p.SetZoneid("all")
 	}
@@ -100,7 +106,9 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 		state.NetworkRate = types.Int32Value(int32(cs.Networkrate))
 	}
 	if cs.Zoneid != "" {
-		state.ZoneIds, _ = types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
+		z, _ := types.SetValueFrom(ctx, types.StringType, strings.Split(cs.Zoneid, ","))
+		state.ZoneIds = z
+		state.ZoneId = z
 	}
 
 	state.DynamicScalingEnabled = types.BoolValue(cs.Dynamicscalingenabled)
@@ -205,9 +213,13 @@ func (plan *serviceOfferingCommonResourceModel) commonCreateParams(ctx context.C
 	if !plan.OfferHa.IsNull() {
 		p.SetOfferha(plan.OfferHa.ValueBool())
 	}
-	if !plan.ZoneIds.IsNull() {
-		zoneIds := make([]string, len(plan.ZoneIds.Elements()))
-		plan.ZoneIds.ElementsAs(ctx, &zoneIds, false)
+	zoneIDs := plan.ZoneIds
+	if zoneIDs.IsNull() || len(zoneIDs.Elements()) == 0 {
+		zoneIDs = plan.ZoneId
+	}
+	if !zoneIDs.IsNull() {
+		zoneIds := make([]string, len(zoneIDs.Elements()))
+		zoneIDs.ElementsAs(ctx, &zoneIds, false)
 		p.SetZoneid(zoneIds)
 	}
 
@@ -260,6 +272,12 @@ func (plan *ServiceOfferingDiskOffering) commonCreateParams(ctx context.Context,
 
 	return p
 
+}
+
+func (plan *serviceOfferingCommonResourceModel) applyLegacyTagsAlias(p *cloudstack.CreateServiceOfferingParams) {
+	if !plan.Tags.IsNull() {
+		p.SetTags(plan.Tags.ValueString())
+	}
 }
 
 func (plan *ServiceOfferingDiskQosStorage) commonCreateParams(ctx context.Context, p *cloudstack.CreateServiceOfferingParams) *cloudstack.CreateServiceOfferingParams {


### PR DESCRIPTION
## Details

### 1. Add `tags`
- Added a `Tags` field to the common service offering model
- Added an optional `tags` attribute to the service offering schema
- Added an `applyTags` helper that sets `tags` on the create params, wired into
  `Create` for all three service offering resources

### 2. Fix `zone_ids` handling
- On read/update state (`commonRead` / `commonUpdate`), a returned zone id of
  `"all"` is no longer written into `zone_ids`; prior state is preserved so that
  a `null` or empty `zone_ids` (both meaning "all zones") doesn't produce a
  spurious diff
- `commonUpdateParams` now correctly serializes `domain_ids` and `zone_ids` by
  joining the set elements with commas instead of using `Set.String()`, and
  defaults `zoneid` to `"all"` when none are set
- `commonCreateParams` zone id handling cleaned up accordingly

### 3. Add import support
- Implemented `ImportState` (via `ImportStatePassthroughID` on `id`) for the
  fixed, constrained, and unconstrained service offering resources
- Added `ImportState` / `ImportStateVerify` steps to the acceptance tests for
  each resource

## Files changed

- `cloudstack/service_offering_constrained_resource.go`
- `cloudstack/service_offering_constrained_resource_test.go`
- `cloudstack/service_offering_fixed_resource.go`
- `cloudstack/service_offering_fixed_resource_test.go`
- `cloudstack/service_offering_models.go`
- `cloudstack/service_offering_schema.go`
- `cloudstack/service_offering_unconstrained_resource.go`
- `cloudstack/service_offering_unconstrained_resource_test.go`
- `cloudstack/service_offering_util.go`

