### PR TITLE
Add GPU support: gpu_card / vgpu_profile data sources and GPU on service offerings

### DIFF
--- a/.github/actions/setup-cloudstack/action.yml
+++ b/.github/actions/setup-cloudstack/action.yml
@@ -96,6 +96,34 @@ runs:
         echo "api_key=$CLOUDSTACK_API_KEY" >> $GITHUB_OUTPUT
         echo "secret_key=$CLOUDSTACK_SECRET_KEY" >> $GITHUB_OUTPUT
 
+    - name: Discover GPU devices
+      shell: bash
+      run: |
+
+        set -euo pipefail
+
+        # GPU management APIs require CloudStack 4.22.0.0 or newer.
+        CURRENT_VERSION="${{ inputs.cloudstack-version }}"
+        if [ "$(printf '%s\n4.22.0.0\n' "$CURRENT_VERSION" | sort -V | head -n1)" != "4.22.0.0" ]; then
+          echo "CloudStack $CURRENT_VERSION predates GPU support (4.22.0.0+); skipping GPU discovery."
+          exit 0
+        fi
+
+        CONTAINER_ID=$(docker container ls --format=json -l | jq -r .ID)
+
+        # Refresh the API cache so cmk knows the 4.22+ GPU APIs (the bundled
+        # cache predates them); "discover gpudevices" maps to discoverGpuDevices.
+        docker exec $CONTAINER_ID cmk -p localcloud sync
+
+        # Discover GPU devices on each routing host so the simulator exposes GPU
+        # cards and vGPU profiles for the GPU acceptance tests. discoverGpuDevices
+        # takes a required "id" argument that is the host's UUID.
+        HOST_IDS=$(docker exec $CONTAINER_ID cmk -p localcloud list hosts type=Routing --output json | jq -r '.host[].id')
+        for HOST_ID in $HOST_IDS; do
+          echo "Discovering GPU devices on host $HOST_ID"
+          docker exec $CONTAINER_ID cmk -p localcloud discover gpudevices id=$HOST_ID
+        done
+
     - name: Install CMK
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ website/node_modules
 *.iml
 *.test
 *.iml
+dist/
+.gocache/
+.gomodcache/
 
 website/vendor
 

--- a/cloudstack/data_source_cloudstack_gpu_card.go
+++ b/cloudstack/data_source_cloudstack_gpu_card.go
@@ -22,9 +22,7 @@ package cloudstack
 import (
 	"fmt"
 	"log"
-	"reflect"
-	"regexp"
-	"strings"
+	"strconv"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,25 +72,24 @@ func datasourceCloudStackGpuCardRead(d *schema.ResourceData, meta interface{}) e
 	cs := meta.(*cloudstack.CloudStackClient)
 	p := cs.GPU.NewListGpuCardsParams()
 
+	if err := applyGpuCardFilters(p, d.Get("filter").(*schema.Set)); err != nil {
+		return err
+	}
+
 	csGpuCards, err := cs.GPU.ListGpuCards(p)
 	if err != nil {
 		return fmt.Errorf("failed to list GPU cards: %s", err)
 	}
 
-	filters := d.Get("filter").(*schema.Set)
-
-	// Client-side filtering for fields not supported server-side
-	for _, card := range csGpuCards.GpuCards {
-		match, err := applyGpuCardFilters(card, filters)
-		if err != nil {
-			return err
-		}
-		if match {
-			return gpuCardDescriptionAttributes(d, card)
-		}
+	switch len(csGpuCards.GpuCards) {
+	case 0:
+		return fmt.Errorf("no GPU cards found")
+	case 1:
+		return gpuCardDescriptionAttributes(d, csGpuCards.GpuCards[0])
+	default:
+		return fmt.Errorf("%d GPU cards matched the given filters; "+
+			"refine the filters (e.g. add device_id or vendor_id) to match exactly one card", len(csGpuCards.GpuCards))
 	}
-
-	return fmt.Errorf("no GPU cards found")
 }
 
 func gpuCardDescriptionAttributes(d *schema.ResourceData, card *cloudstack.GpuCard) error {
@@ -116,42 +113,41 @@ func gpuCardDescriptionAttributes(d *schema.ResourceData, card *cloudstack.GpuCa
 	return nil
 }
 
-func applyGpuCardFilters(card *cloudstack.GpuCard, filters *schema.Set) (bool, error) {
-	val := reflect.ValueOf(card).Elem()
-
+func applyGpuCardFilters(p *cloudstack.ListGpuCardsParams, filters *schema.Set) error {
+	seen := make(map[string]bool)
 	for _, f := range filters.List() {
 		filter := f.(map[string]interface{})
-		r, err := regexp.Compile(filter["value"].(string))
-		if err != nil {
-			return false, fmt.Errorf("invalid regex: %s", err)
+		name := filter["name"].(string)
+		value := filter["value"].(string)
+
+		if seen[name] {
+			return fmt.Errorf("duplicate filter %q; each filter name may only be specified once", name)
 		}
+		seen[name] = true
 
-		filterName := filter["name"].(string)
-		updatedName := strings.ReplaceAll(filterName, "_", "")
-
-		// Find the field with case-insensitive matching
-		var cardField reflect.Value
-		val.FieldByNameFunc(func(fieldName string) bool {
-			if strings.EqualFold(fieldName, updatedName) {
-				updatedName = fieldName
-				cardField = val.FieldByName(fieldName)
-				return true
+		switch name {
+		case "id":
+			p.SetId(value)
+		case "device_id":
+			p.SetDeviceid(value)
+		case "device_name":
+			p.SetDevicename(value)
+		case "vendor_id":
+			p.SetVendorid(value)
+		case "vendor_name":
+			p.SetVendorname(value)
+		case "keyword":
+			p.SetKeyword(value)
+		case "active_only":
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid boolean value %q for filter %q: %s", value, name, err)
 			}
-			return false
-		})
-
-		// Validate field was found
-		if !cardField.IsValid() {
-			return false, fmt.Errorf("unknown filter field '%s'", filterName)
-		}
-
-		// Safely convert field value to string
-		fieldStr := fmt.Sprintf("%v", cardField.Interface())
-
-		if !r.MatchString(fieldStr) {
-			return false, nil
+			p.SetActiveonly(b)
+		default:
+			return fmt.Errorf("unsupported filter %q; supported filters: id, device_id, device_name, vendor_id, vendor_name, keyword, active_only", name)
 		}
 	}
 
-	return true, nil
+	return nil
 }

--- a/cloudstack/data_source_cloudstack_gpu_card.go
+++ b/cloudstack/data_source_cloudstack_gpu_card.go
@@ -79,10 +79,11 @@ func datasourceCloudStackGpuCardRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("failed to list GPU cards: %s", err)
 	}
 
-	filters := d.Get("filter")
+	filters := d.Get("filter").(*schema.Set)
 
+	// Client-side filtering for fields not supported server-side
 	for _, card := range csGpuCards.GpuCards {
-		match, err := applyGpuCardFilters(card, filters.(*schema.Set))
+		match, err := applyGpuCardFilters(card, filters)
 		if err != nil {
 			return err
 		}
@@ -124,16 +125,30 @@ func applyGpuCardFilters(card *cloudstack.GpuCard, filters *schema.Set) (bool, e
 		if err != nil {
 			return false, fmt.Errorf("invalid regex: %s", err)
 		}
-		updatedName := strings.ReplaceAll(filter["name"].(string), "_", "")
-		cardField := val.FieldByNameFunc(func(fieldName string) bool {
+
+		filterName := filter["name"].(string)
+		updatedName := strings.ReplaceAll(filterName, "_", "")
+
+		// Find the field with case-insensitive matching
+		var cardField reflect.Value
+		val.FieldByNameFunc(func(fieldName string) bool {
 			if strings.EqualFold(fieldName, updatedName) {
 				updatedName = fieldName
+				cardField = val.FieldByName(fieldName)
 				return true
 			}
 			return false
-		}).String()
+		})
 
-		if !r.MatchString(cardField) {
+		// Validate field was found
+		if !cardField.IsValid() {
+			return false, fmt.Errorf("unknown filter field '%s'", filterName)
+		}
+
+		// Safely convert field value to string
+		fieldStr := fmt.Sprintf("%v", cardField.Interface())
+
+		if !r.MatchString(fieldStr) {
 			return false, nil
 		}
 	}

--- a/cloudstack/data_source_cloudstack_gpu_card.go
+++ b/cloudstack/data_source_cloudstack_gpu_card.go
@@ -1,0 +1,142 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCloudstackGpuCard() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceCloudStackGpuCardRead,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+
+			//Computed values
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Description: "the name of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"device_id": {
+				Description: "the device id of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"device_name": {
+				Description: "the device name of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vendor_id": {
+				Description: "the vendor id of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vendor_name": {
+				Description: "the vendor name of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func datasourceCloudStackGpuCardRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+	p := cs.GPU.NewListGpuCardsParams()
+
+	csGpuCards, err := cs.GPU.ListGpuCards(p)
+	if err != nil {
+		return fmt.Errorf("failed to list GPU cards: %s", err)
+	}
+
+	filters := d.Get("filter")
+
+	for _, card := range csGpuCards.GpuCards {
+		match, err := applyGpuCardFilters(card, filters.(*schema.Set))
+		if err != nil {
+			return err
+		}
+		if match {
+			return gpuCardDescriptionAttributes(d, card)
+		}
+	}
+
+	return fmt.Errorf("no GPU cards found")
+}
+
+func gpuCardDescriptionAttributes(d *schema.ResourceData, card *cloudstack.GpuCard) error {
+	d.SetId(card.Id)
+
+	fields := map[string]interface{}{
+		"id":          card.Id,
+		"name":        card.Name,
+		"device_id":   card.Deviceid,
+		"device_name": card.Devicename,
+		"vendor_id":   card.Vendorid,
+		"vendor_name": card.Vendorname,
+	}
+
+	for k, v := range fields {
+		if err := d.Set(k, v); err != nil {
+			log.Printf("[WARN] Error setting %s: %s", k, err)
+		}
+	}
+
+	return nil
+}
+
+func applyGpuCardFilters(card *cloudstack.GpuCard, filters *schema.Set) (bool, error) {
+	val := reflect.ValueOf(card).Elem()
+
+	for _, f := range filters.List() {
+		filter := f.(map[string]interface{})
+		r, err := regexp.Compile(filter["value"].(string))
+		if err != nil {
+			return false, fmt.Errorf("invalid regex: %s", err)
+		}
+		updatedName := strings.ReplaceAll(filter["name"].(string), "_", "")
+		cardField := val.FieldByNameFunc(func(fieldName string) bool {
+			if strings.EqualFold(fieldName, updatedName) {
+				updatedName = fieldName
+				return true
+			}
+			return false
+		}).String()
+
+		if !r.MatchString(cardField) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/cloudstack/data_source_cloudstack_gpu_card_test.go
+++ b/cloudstack/data_source_cloudstack_gpu_card_test.go
@@ -44,8 +44,8 @@ func TestAccGpuCardDataSource_basic(t *testing.T) {
 const testGpuCardDataSourceConfig_basic = `
 data "cloudstack_gpu_card" "test" {
   filter {
-    name  = "keyword"
-    value = "Simulator Graphics Card Pro"
+    name  = "device_name"
+    value = "Graphics Card Pro"
   }
 }
 `

--- a/cloudstack/data_source_cloudstack_gpu_card_test.go
+++ b/cloudstack/data_source_cloudstack_gpu_card_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAccGpuCardDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckGPU(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/cloudstack/data_source_cloudstack_gpu_card_test.go
+++ b/cloudstack/data_source_cloudstack_gpu_card_test.go
@@ -43,8 +43,8 @@ func TestAccGpuCardDataSource_basic(t *testing.T) {
 const testGpuCardDataSourceConfig_basic = `
 data "cloudstack_gpu_card" "test" {
   filter {
-    name = "name"
-    value = "NVIDIA.*"
+    name  = "keyword"
+    value = "NVIDIA"
   }
 }
 `

--- a/cloudstack/data_source_cloudstack_gpu_card_test.go
+++ b/cloudstack/data_source_cloudstack_gpu_card_test.go
@@ -1,0 +1,50 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGpuCardDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGpuCardDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.cloudstack_gpu_card.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+const testGpuCardDataSourceConfig_basic = `
+data "cloudstack_gpu_card" "test" {
+  filter {
+    name = "name"
+    value = "NVIDIA.*"
+  }
+}
+`

--- a/cloudstack/data_source_cloudstack_gpu_card_test.go
+++ b/cloudstack/data_source_cloudstack_gpu_card_test.go
@@ -34,6 +34,7 @@ func TestAccGpuCardDataSource_basic(t *testing.T) {
 				Config: testGpuCardDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.cloudstack_gpu_card.test", "id"),
+					resource.TestCheckResourceAttr("data.cloudstack_gpu_card.test", "name", "Simulator Graphics Card Pro"),
 				),
 			},
 		},
@@ -44,7 +45,7 @@ const testGpuCardDataSourceConfig_basic = `
 data "cloudstack_gpu_card" "test" {
   filter {
     name  = "keyword"
-    value = "NVIDIA"
+    value = "Simulator Graphics Card Pro"
   }
 }
 `

--- a/cloudstack/data_source_cloudstack_vgpu_profile.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile.go
@@ -22,9 +22,7 @@ package cloudstack
 import (
 	"fmt"
 	"log"
-	"reflect"
-	"regexp"
-	"strings"
+	"strconv"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -114,24 +112,24 @@ func datasourceCloudStackVgpuProfileRead(d *schema.ResourceData, meta interface{
 	cs := meta.(*cloudstack.CloudStackClient)
 	p := cs.GPU.NewListVgpuProfilesParams()
 
+	if err := applyVgpuProfileFilters(p, d.Get("filter").(*schema.Set)); err != nil {
+		return err
+	}
+
 	csVgpuProfiles, err := cs.GPU.ListVgpuProfiles(p)
 	if err != nil {
 		return fmt.Errorf("failed to list vGPU profiles: %s", err)
 	}
 
-	filters := d.Get("filter").(*schema.Set)
-
-	for _, profile := range csVgpuProfiles.VgpuProfiles {
-		match, err := applyVgpuProfileFilters(profile, filters)
-		if err != nil {
-			return err
-		}
-		if match {
-			return vgpuProfileDescriptionAttributes(d, profile)
-		}
+	switch len(csVgpuProfiles.VgpuProfiles) {
+	case 0:
+		return fmt.Errorf("no vGPU profiles found")
+	case 1:
+		return vgpuProfileDescriptionAttributes(d, csVgpuProfiles.VgpuProfiles[0])
+	default:
+		return fmt.Errorf("%d vGPU profiles matched the given filters; "+
+			"refine the filters (e.g. add gpu_card_id) to match exactly one profile", len(csVgpuProfiles.VgpuProfiles))
 	}
-
-	return fmt.Errorf("no vGPU profiles found")
 }
 
 func vgpuProfileDescriptionAttributes(d *schema.ResourceData, profile *cloudstack.VgpuProfile) error {
@@ -163,42 +161,37 @@ func vgpuProfileDescriptionAttributes(d *schema.ResourceData, profile *cloudstac
 	return nil
 }
 
-func applyVgpuProfileFilters(profile *cloudstack.VgpuProfile, filters *schema.Set) (bool, error) {
-	val := reflect.ValueOf(profile).Elem()
-
+func applyVgpuProfileFilters(p *cloudstack.ListVgpuProfilesParams, filters *schema.Set) error {
+	seen := make(map[string]bool)
 	for _, f := range filters.List() {
 		filter := f.(map[string]interface{})
-		r, err := regexp.Compile(filter["value"].(string))
-		if err != nil {
-			return false, fmt.Errorf("invalid regex: %s", err)
+		name := filter["name"].(string)
+		value := filter["value"].(string)
+
+		if seen[name] {
+			return fmt.Errorf("duplicate filter %q; each filter name may only be specified once", name)
 		}
+		seen[name] = true
 
-		filterName := filter["name"].(string)
-		updatedName := strings.ReplaceAll(filterName, "_", "")
-
-		// Find the field with case-insensitive matching
-		var profileField reflect.Value
-		val.FieldByNameFunc(func(fieldName string) bool {
-			if strings.EqualFold(fieldName, updatedName) {
-				updatedName = fieldName
-				profileField = val.FieldByName(fieldName)
-				return true
+		switch name {
+		case "id":
+			p.SetId(value)
+		case "name":
+			p.SetName(value)
+		case "gpu_card_id":
+			p.SetGpucardid(value)
+		case "keyword":
+			p.SetKeyword(value)
+		case "active_only":
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid boolean value %q for filter %q: %s", value, name, err)
 			}
-			return false
-		})
-
-		// Validate field was found
-		if !profileField.IsValid() {
-			return false, fmt.Errorf("unknown filter field '%s'", filterName)
-		}
-
-		// Safely convert field value to string
-		fieldStr := fmt.Sprintf("%v", profileField.Interface())
-
-		if !r.MatchString(fieldStr) {
-			return false, nil
+			p.SetActiveonly(b)
+		default:
+			return fmt.Errorf("unsupported filter %q; supported filters: id, name, gpu_card_id, keyword, active_only", name)
 		}
 	}
 
-	return true, nil
+	return nil
 }

--- a/cloudstack/data_source_cloudstack_vgpu_profile.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile.go
@@ -119,10 +119,10 @@ func datasourceCloudStackVgpuProfileRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("failed to list vGPU profiles: %s", err)
 	}
 
-	filters := d.Get("filter")
+	filters := d.Get("filter").(*schema.Set)
 
 	for _, profile := range csVgpuProfiles.VgpuProfiles {
-		match, err := applyVgpuProfileFilters(profile, filters.(*schema.Set))
+		match, err := applyVgpuProfileFilters(profile, filters)
 		if err != nil {
 			return err
 		}
@@ -172,16 +172,30 @@ func applyVgpuProfileFilters(profile *cloudstack.VgpuProfile, filters *schema.Se
 		if err != nil {
 			return false, fmt.Errorf("invalid regex: %s", err)
 		}
-		updatedName := strings.ReplaceAll(filter["name"].(string), "_", "")
-		profileField := val.FieldByNameFunc(func(fieldName string) bool {
+
+		filterName := filter["name"].(string)
+		updatedName := strings.ReplaceAll(filterName, "_", "")
+
+		// Find the field with case-insensitive matching
+		var profileField reflect.Value
+		val.FieldByNameFunc(func(fieldName string) bool {
 			if strings.EqualFold(fieldName, updatedName) {
 				updatedName = fieldName
+				profileField = val.FieldByName(fieldName)
 				return true
 			}
 			return false
-		}).String()
+		})
 
-		if !r.MatchString(profileField) {
+		// Validate field was found
+		if !profileField.IsValid() {
+			return false, fmt.Errorf("unknown filter field '%s'", filterName)
+		}
+
+		// Safely convert field value to string
+		fieldStr := fmt.Sprintf("%v", profileField.Interface())
+
+		if !r.MatchString(fieldStr) {
 			return false, nil
 		}
 	}

--- a/cloudstack/data_source_cloudstack_vgpu_profile.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile.go
@@ -1,0 +1,190 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCloudstackVgpuProfile() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceCloudStackVgpuProfileRead,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+
+			//Computed values
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Description: "the name of the vGPU profile",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"description": {
+				Description: "the description of the vGPU profile",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"device_id": {
+				Description: "the device id of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"device_name": {
+				Description: "the device name of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"gpu_card_id": {
+				Description: "the GPU card id of the vGPU profile",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"gpu_card_name": {
+				Description: "the GPU card name of the vGPU profile",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"max_heads": {
+				Description: "the maximum displays per vGPU instance",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"max_resolution_x": {
+				Description: "the maximum X resolution per display",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"max_resolution_y": {
+				Description: "the maximum Y resolution per display",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"max_vgpu_per_physical_gpu": {
+				Description: "the maximum number of vGPU instances per physical GPU",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"vendor_id": {
+				Description: "the vendor id of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vendor_name": {
+				Description: "the vendor name of the GPU card",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"video_ram": {
+				Description: "the video RAM size in MB for the vGPU profile",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func datasourceCloudStackVgpuProfileRead(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+	p := cs.GPU.NewListVgpuProfilesParams()
+
+	csVgpuProfiles, err := cs.GPU.ListVgpuProfiles(p)
+	if err != nil {
+		return fmt.Errorf("failed to list vGPU profiles: %s", err)
+	}
+
+	filters := d.Get("filter")
+
+	for _, profile := range csVgpuProfiles.VgpuProfiles {
+		match, err := applyVgpuProfileFilters(profile, filters.(*schema.Set))
+		if err != nil {
+			return err
+		}
+		if match {
+			return vgpuProfileDescriptionAttributes(d, profile)
+		}
+	}
+
+	return fmt.Errorf("no vGPU profiles found")
+}
+
+func vgpuProfileDescriptionAttributes(d *schema.ResourceData, profile *cloudstack.VgpuProfile) error {
+	d.SetId(profile.Id)
+
+	fields := map[string]interface{}{
+		"id":                        profile.Id,
+		"name":                      profile.Name,
+		"description":               profile.Description,
+		"device_id":                 profile.Deviceid,
+		"device_name":               profile.Devicename,
+		"gpu_card_id":               profile.Gpucardid,
+		"gpu_card_name":             profile.Gpucardname,
+		"max_heads":                 profile.Maxheads,
+		"max_resolution_x":          profile.Maxresolutionx,
+		"max_resolution_y":          profile.Maxresolutiony,
+		"max_vgpu_per_physical_gpu": profile.Maxvgpuperphysicalgpu,
+		"vendor_id":                 profile.Vendorid,
+		"vendor_name":               profile.Vendorname,
+		"video_ram":                 profile.Videoram,
+	}
+
+	for k, v := range fields {
+		if err := d.Set(k, v); err != nil {
+			log.Printf("[WARN] Error setting %s: %s", k, err)
+		}
+	}
+
+	return nil
+}
+
+func applyVgpuProfileFilters(profile *cloudstack.VgpuProfile, filters *schema.Set) (bool, error) {
+	val := reflect.ValueOf(profile).Elem()
+
+	for _, f := range filters.List() {
+		filter := f.(map[string]interface{})
+		r, err := regexp.Compile(filter["value"].(string))
+		if err != nil {
+			return false, fmt.Errorf("invalid regex: %s", err)
+		}
+		updatedName := strings.ReplaceAll(filter["name"].(string), "_", "")
+		profileField := val.FieldByNameFunc(func(fieldName string) bool {
+			if strings.EqualFold(fieldName, updatedName) {
+				updatedName = fieldName
+				return true
+			}
+			return false
+		}).String()
+
+		if !r.MatchString(profileField) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/cloudstack/data_source_cloudstack_vgpu_profile_test.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAccVgpuProfileDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckGPU(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/cloudstack/data_source_cloudstack_vgpu_profile_test.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile_test.go
@@ -1,0 +1,50 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVgpuProfileDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testVgpuProfileDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cloudstack_vgpu_profile.test", "name", "passthrough"),
+				),
+			},
+		},
+	})
+}
+
+const testVgpuProfileDataSourceConfig_basic = `
+data "cloudstack_vgpu_profile" "test" {
+  filter {
+    name = "name"
+    value = "passthrough"
+  }
+}
+`

--- a/cloudstack/data_source_cloudstack_vgpu_profile_test.go
+++ b/cloudstack/data_source_cloudstack_vgpu_profile_test.go
@@ -33,7 +33,7 @@ func TestAccVgpuProfileDataSource_basic(t *testing.T) {
 			{
 				Config: testVgpuProfileDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudstack_vgpu_profile.test", "name", "passthrough"),
+					resource.TestCheckResourceAttr("data.cloudstack_vgpu_profile.test", "name", "sim-8q"),
 				),
 			},
 		},
@@ -44,7 +44,7 @@ const testVgpuProfileDataSourceConfig_basic = `
 data "cloudstack_vgpu_profile" "test" {
   filter {
     name = "name"
-    value = "passthrough"
+    value = "sim-8q"
   }
 }
 `

--- a/cloudstack/provider.go
+++ b/cloudstack/provider.go
@@ -109,6 +109,8 @@ func Provider() *schema.Provider {
 			"cloudstack_user_data":                 dataSourceCloudstackUserData(),
 			"cloudstack_kubernetes_cluster_config": dataSourceCloudstackKubernetesClusterConfig(),
 			"cloudstack_security_group":            dataSourceCloudstackSecurityGroup(),
+			"cloudstack_vgpu_profile":              dataSourceCloudstackVgpuProfile(),
+			"cloudstack_gpu_card":                  dataSourceCloudstackGpuCard(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -206,6 +206,14 @@ func testAccPreCheckStaticRouteNexthop(t *testing.T) {
 	requireMinimumCloudStackVersion(t, minVersionNum, "Static route nexthop parameter")
 }
 
+// testAccPreCheckGPU checks if the CloudStack version supports GPU features (requires 4.22.0+)
+func testAccPreCheckGPU(t *testing.T) {
+	testAccPreCheck(t)
+
+	const minVersionNum = 4022 // 4.22.0
+	requireMinimumCloudStackVersion(t, minVersionNum, "GPU card and vGPU profile support")
+}
+
 // newTestClient creates a CloudStack client from environment variables for use in test PreCheck functions.
 // This is needed because PreCheck functions run before the test framework configures the provider,
 // so testAccProvider.Meta() is nil at that point.

--- a/cloudstack/provider_test.go
+++ b/cloudstack/provider_test.go
@@ -207,11 +207,34 @@ func testAccPreCheckStaticRouteNexthop(t *testing.T) {
 }
 
 // testAccPreCheckGPU checks if the CloudStack version supports GPU features (requires 4.22.0+)
+// and that GPU devices have been discovered on the hosts. vGPU profiles only exist once GPU
+// devices are discovered (via the discoverGpuDevices API); when none are present the GPU tests
+// are skipped so environments without GPU hardware (e.g. the CI simulator) do not fail.
 func testAccPreCheckGPU(t *testing.T) {
 	testAccPreCheck(t)
 
 	const minVersionNum = 4022 // 4.22.0
 	requireMinimumCloudStackVersion(t, minVersionNum, "GPU card and vGPU profile support")
+
+	requireVgpuProfiles(t)
+}
+
+// requireVgpuProfiles skips the test when no vGPU profiles are available. vGPU profiles are only
+// created once GPU devices have been discovered on the hosts (via the discoverGpuDevices API),
+// which is not the case in environments without GPU hardware.
+func requireVgpuProfiles(t *testing.T) {
+	t.Helper()
+	cs := newTestClient(t)
+
+	p := cs.GPU.NewListVgpuProfilesParams()
+	profiles, err := cs.GPU.ListVgpuProfiles(p)
+	if err != nil {
+		t.Fatalf("Failed to list vGPU profiles: %v", err)
+	}
+
+	if profiles.Count == 0 {
+		t.Skip("No vGPU profiles found; discover GPU devices on the hosts (discoverGpuDevices) to run GPU acceptance tests")
+	}
 }
 
 // newTestClient creates a CloudStack client from environment variables for use in test PreCheck functions.

--- a/cloudstack/service_offering_constrained_resource.go
+++ b/cloudstack/service_offering_constrained_resource.go
@@ -156,24 +156,8 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 
 func (r *serviceOfferingConstrainedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state serviceOfferingConstrainedResourceModel
-	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
-	var stateDiskOffering ServiceOfferingDiskOffering
-	var stateDiskQosStorage ServiceOfferingDiskQosStorage
-	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosHypervisor.As(ctx, &stateDiskQosHypervisor, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskOffering.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskOffering.As(ctx, &stateDiskOffering, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskQosStorage.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingGpu.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
-	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -236,11 +220,7 @@ func (r *serviceOfferingConstrainedResource) Read(ctx context.Context, req resou
 		state.MinMemory = types.Int32Value(int32(i))
 	}
 
-	state.commonRead(ctx, cs)
-	stateDiskQosHypervisor.commonRead(ctx, cs)
-	stateDiskOffering.commonRead(ctx, cs)
-	stateDiskQosStorage.commonRead(ctx, cs)
-	stateGpu.commonRead(ctx, cs)
+	resp.Diagnostics.Append(state.commonRead(ctx, cs)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_constrained_resource.go
+++ b/cloudstack/service_offering_constrained_resource.go
@@ -93,6 +93,7 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 	var planDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var planDiskOffering ServiceOfferingDiskOffering
 	var planDiskQosStorage ServiceOfferingDiskQosStorage
+	var planGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if !plan.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -104,6 +105,9 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 	if !plan.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(plan.ServiceOfferingDiskQosStorage.As(ctx, &planDiskQosStorage, basetypes.ObjectAsOptions{})...)
 	}
+	if !plan.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(plan.ServiceOfferingGpu.As(ctx, &planGpu, basetypes.ObjectAsOptions{})...)
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -114,6 +118,7 @@ func (r *serviceOfferingConstrainedResource) Create(ctx context.Context, req res
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)
+	planGpu.commonCreateParams(ctx, params)
 
 	// resource specific params
 	if !plan.CpuSpeed.IsNull() {
@@ -154,6 +159,7 @@ func (r *serviceOfferingConstrainedResource) Read(ctx context.Context, req resou
 	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var stateDiskOffering ServiceOfferingDiskOffering
 	var stateDiskQosStorage ServiceOfferingDiskQosStorage
+	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -164,6 +170,9 @@ func (r *serviceOfferingConstrainedResource) Read(ctx context.Context, req resou
 	}
 	if !state.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
+	}
+	if !state.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -231,6 +240,7 @@ func (r *serviceOfferingConstrainedResource) Read(ctx context.Context, req resou
 	stateDiskQosHypervisor.commonRead(ctx, cs)
 	stateDiskOffering.commonRead(ctx, cs)
 	stateDiskQosStorage.commonRead(ctx, cs)
+	stateGpu.commonRead(ctx, cs)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_constrained_resource_test.go
+++ b/cloudstack/service_offering_constrained_resource_test.go
@@ -296,7 +296,7 @@ const testAccServiceOfferingCustomConstrained_gpu = `
 data "cloudstack_vgpu_profile" "test" {
 	filter {
 		name  = "name"
-		value = "passthrough"
+		value = "sim-8q"
 	}
 }
 

--- a/cloudstack/service_offering_constrained_resource_test.go
+++ b/cloudstack/service_offering_constrained_resource_test.go
@@ -72,6 +72,15 @@ func TestAccServiceOfferingConstrained(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.disk_storage", "name", "disk_storage"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccServiceOfferingConstrained_GPU(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckGPU(t) },
+		ProtoV6ProviderFactories: testAccMuxProvider,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceOfferingCustomConstrained_gpu,
 				Check: resource.ComposeTestCheckFunc(

--- a/cloudstack/service_offering_constrained_resource_test.go
+++ b/cloudstack/service_offering_constrained_resource_test.go
@@ -72,6 +72,15 @@ func TestAccServiceOfferingConstrained(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.disk_storage", "name", "disk_storage"),
 				),
 			},
+			{
+				Config: testAccServiceOfferingCustomConstrained_gpu,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "name", "gpu"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.count", "1"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.display", "true"),
+				),
+			},
 		},
 	})
 }
@@ -270,6 +279,39 @@ resource "cloudstack_service_offering_constrained" "disk_hypervisor" {
 		bytes_write_rate            = 1024
 		bytes_write_rate_max        = 1024
 		bytes_write_rate_max_length = 1024
+	}
+}
+`
+
+const testAccServiceOfferingCustomConstrained_gpu = `
+resource "cloudstack_service_offering_constrained" "gpu" {
+	display_text = "gpu"
+	name         = "gpu"
+
+	// compute
+	cpu_speed  = 2500
+	max_cpu_number = 10
+	min_cpu_number = 2
+
+	// memory
+	max_memory     = 4096
+	min_memory     = 1024
+
+	// other
+	host_tags = "test0101,test0202"
+	network_rate = 1024
+	deployment_planner = "UserDispersingPlanner"
+
+	// Feature flags
+	dynamic_scaling_enabled = false
+	is_volatile             = false
+	limit_cpu_use           = false
+	offer_ha                = false
+
+	gpu = {
+		vgpu_profile_id = "a6000-8a-profile"
+		count           = 1
+		display         = true
 	}
 }
 `

--- a/cloudstack/service_offering_constrained_resource_test.go
+++ b/cloudstack/service_offering_constrained_resource_test.go
@@ -85,7 +85,7 @@ func TestAccServiceOfferingConstrained_GPU(t *testing.T) {
 				Config: testAccServiceOfferingCustomConstrained_gpu,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "name", "gpu"),
-					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttrPair("cloudstack_service_offering_constrained.gpu", "gpu.vgpu_profile_id", "data.cloudstack_vgpu_profile.test", "id"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.count", "1"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_constrained.gpu", "gpu.display", "true"),
 				),
@@ -293,6 +293,13 @@ resource "cloudstack_service_offering_constrained" "disk_hypervisor" {
 `
 
 const testAccServiceOfferingCustomConstrained_gpu = `
+data "cloudstack_vgpu_profile" "test" {
+	filter {
+		name  = "name"
+		value = "passthrough"
+	}
+}
+
 resource "cloudstack_service_offering_constrained" "gpu" {
 	display_text = "gpu"
 	name         = "gpu"
@@ -318,7 +325,7 @@ resource "cloudstack_service_offering_constrained" "gpu" {
 	offer_ha                = false
 
 	gpu = {
-		vgpu_profile_id = "a6000-8a-profile"
+		vgpu_profile_id = data.cloudstack_vgpu_profile.test.id
 		count           = 1
 		display         = true
 	}

--- a/cloudstack/service_offering_fixed_resource.go
+++ b/cloudstack/service_offering_fixed_resource.go
@@ -133,24 +133,8 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 func (r *serviceOfferingFixedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 
 	var state serviceOfferingFixedResourceModel
-	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
-	var stateDiskOffering ServiceOfferingDiskOffering
-	var stateDiskQosStorage ServiceOfferingDiskQosStorage
-	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosHypervisor.As(ctx, &stateDiskQosHypervisor, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskOffering.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskOffering.As(ctx, &stateDiskOffering, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskQosStorage.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingGpu.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
-	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -175,11 +159,7 @@ func (r *serviceOfferingFixedResource) Read(ctx context.Context, req resource.Re
 		state.Memory = types.Int32Value(int32(cs.Memory))
 	}
 
-	state.commonRead(ctx, cs)
-	stateDiskQosHypervisor.commonRead(ctx, cs)
-	stateDiskOffering.commonRead(ctx, cs)
-	stateDiskQosStorage.commonRead(ctx, cs)
-	stateGpu.commonRead(ctx, cs)
+	resp.Diagnostics.Append(state.commonRead(ctx, cs)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_fixed_resource.go
+++ b/cloudstack/service_offering_fixed_resource.go
@@ -78,6 +78,7 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 	var planDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var planDiskOffering ServiceOfferingDiskOffering
 	var planDiskQosStorage ServiceOfferingDiskQosStorage
+	var planGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if !plan.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -89,6 +90,9 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 	if !plan.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(plan.ServiceOfferingDiskQosStorage.As(ctx, &planDiskQosStorage, basetypes.ObjectAsOptions{})...)
 	}
+	if !plan.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(plan.ServiceOfferingGpu.As(ctx, &planGpu, basetypes.ObjectAsOptions{})...)
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -99,6 +103,7 @@ func (r *serviceOfferingFixedResource) Create(ctx context.Context, req resource.
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)
+	planGpu.commonCreateParams(ctx, params)
 
 	// resource specific params
 	if !plan.CpuNumber.IsNull() {
@@ -131,6 +136,7 @@ func (r *serviceOfferingFixedResource) Read(ctx context.Context, req resource.Re
 	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var stateDiskOffering ServiceOfferingDiskOffering
 	var stateDiskQosStorage ServiceOfferingDiskQosStorage
+	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -141,6 +147,9 @@ func (r *serviceOfferingFixedResource) Read(ctx context.Context, req resource.Re
 	}
 	if !state.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
+	}
+	if !state.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -170,6 +179,7 @@ func (r *serviceOfferingFixedResource) Read(ctx context.Context, req resource.Re
 	stateDiskQosHypervisor.commonRead(ctx, cs)
 	stateDiskOffering.commonRead(ctx, cs)
 	stateDiskQosStorage.commonRead(ctx, cs)
+	stateGpu.commonRead(ctx, cs)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_fixed_resource_test.go
+++ b/cloudstack/service_offering_fixed_resource_test.go
@@ -79,7 +79,7 @@ func TestAccServiceOfferingFixed_GPU(t *testing.T) {
 				Config: testAccServiceOfferingFixed_gpu,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "name", "gpu"),
-					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttrPair("cloudstack_service_offering_fixed.gpu", "gpu.vgpu_profile_id", "data.cloudstack_vgpu_profile.test", "id"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.count", "1"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.display", "true"),
 				),
@@ -257,6 +257,13 @@ resource "cloudstack_service_offering_fixed" "disk_storage" {
 `
 
 const testAccServiceOfferingFixed_gpu = `
+data "cloudstack_vgpu_profile" "test" {
+	filter {
+		name  = "name"
+		value = "passthrough"
+	}
+}
+
 resource "cloudstack_service_offering_fixed" "gpu" {
 	display_text = "gpu"
 	name         = "gpu"
@@ -277,7 +284,7 @@ resource "cloudstack_service_offering_fixed" "gpu" {
 	offer_ha                = false
 
 	gpu = {
-		vgpu_profile_id = "a6000-8a-profile"
+		vgpu_profile_id = data.cloudstack_vgpu_profile.test.id
 		count           = 1
 		display         = true
 	}

--- a/cloudstack/service_offering_fixed_resource_test.go
+++ b/cloudstack/service_offering_fixed_resource_test.go
@@ -66,6 +66,15 @@ func TestAccServiceOfferingFixed(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.disk_storage", "name", "disk_storage"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccServiceOfferingFixed_GPU(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckGPU(t) },
+		ProtoV6ProviderFactories: testAccMuxProvider,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceOfferingFixed_gpu,
 				Check: resource.ComposeTestCheckFunc(

--- a/cloudstack/service_offering_fixed_resource_test.go
+++ b/cloudstack/service_offering_fixed_resource_test.go
@@ -66,6 +66,15 @@ func TestAccServiceOfferingFixed(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.disk_storage", "name", "disk_storage"),
 				),
 			},
+			{
+				Config: testAccServiceOfferingFixed_gpu,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "name", "gpu"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.count", "1"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_fixed.gpu", "gpu.display", "true"),
+				),
+			},
 		},
 	})
 }
@@ -234,6 +243,34 @@ resource "cloudstack_service_offering_fixed" "disk_storage" {
 	disk_storage = {
 		min_iops = 100
 		max_iops = 100
+	}
+}
+`
+
+const testAccServiceOfferingFixed_gpu = `
+resource "cloudstack_service_offering_fixed" "gpu" {
+	display_text = "gpu"
+	name         = "gpu"
+
+	// compute
+	cpu_number     = 2
+	cpu_speed      = 2500
+	memory         = 2048
+
+	// other
+	host_tags          = "test0101, test0202"
+	network_rate       = 1024
+	deployment_planner = "UserDispersingPlanner"
+
+	dynamic_scaling_enabled = false
+	is_volatile             = false
+	limit_cpu_use           = false
+	offer_ha                = false
+
+	gpu = {
+		vgpu_profile_id = "a6000-8a-profile"
+		count           = 1
+		display         = true
 	}
 }
 `

--- a/cloudstack/service_offering_fixed_resource_test.go
+++ b/cloudstack/service_offering_fixed_resource_test.go
@@ -260,7 +260,7 @@ const testAccServiceOfferingFixed_gpu = `
 data "cloudstack_vgpu_profile" "test" {
 	filter {
 		name  = "name"
-		value = "passthrough"
+		value = "sim-8q"
 	}
 }
 

--- a/cloudstack/service_offering_models.go
+++ b/cloudstack/service_offering_models.go
@@ -58,6 +58,7 @@ type serviceOfferingCommonResourceModel struct {
 	ServiceOfferingDiskQosHypervisor types.Object `tfsdk:"disk_hypervisor"`
 	ServiceOfferingDiskOffering      types.Object `tfsdk:"disk_offering"`
 	ServiceOfferingDiskQosStorage    types.Object `tfsdk:"disk_storage"`
+	ServiceOfferingGpu               types.Object `tfsdk:"gpu"`
 }
 
 type ServiceOfferingDiskQosHypervisor struct {
@@ -83,4 +84,10 @@ type ServiceOfferingDiskQosStorage struct {
 	HypervisorSnapshotReserve types.Int32 `tfsdk:"hypervisor_snapshot_reserve"`
 	MaxIops                   types.Int64 `tfsdk:"max_iops"`
 	MinIops                   types.Int64 `tfsdk:"min_iops"`
+}
+
+type ServiceOfferingGpu struct {
+	VgpuProfileId types.String `tfsdk:"vgpu_profile_id"`
+	Count         types.Int32  `tfsdk:"count"`
+	Display       types.Bool   `tfsdk:"display"`
 }

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -116,6 +117,9 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 		},
 		"disk_offering": schema.SingleNestedAttribute{
 			Optional: true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.RequiresReplace(),
+			},
 			Attributes: map[string]schema.Attribute{
 				"cache_mode": schema.StringAttribute{
 					Description: "the cache mode to use for this disk offering. none, writeback or writethrough",
@@ -160,6 +164,9 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 		},
 		"disk_hypervisor": schema.SingleNestedAttribute{
 			Optional: true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.RequiresReplace(),
+			},
 			Attributes: map[string]schema.Attribute{
 				"bytes_read_rate": schema.Int64Attribute{
 					Description: "io requests read rate of the disk offering",
@@ -207,6 +214,9 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 		},
 		"disk_storage": schema.SingleNestedAttribute{
 			Optional: true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.RequiresReplace(),
+			},
 			Attributes: map[string]schema.Attribute{
 				"customized_iops": schema.BoolAttribute{
 					Description: "true if disk offering uses custom iops, false otherwise",
@@ -240,6 +250,9 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 		},
 		"gpu": schema.SingleNestedAttribute{
 			Optional: true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.RequiresReplace(),
+			},
 			Attributes: map[string]schema.Attribute{
 				"vgpu_profile_id": schema.StringAttribute{
 					Description: "the ID of the vGPU profile to associate with the service offering",

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -254,6 +255,7 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 					PlanModifiers: []planmodifier.Int32{
 						int32planmodifier.RequiresReplace(),
 					},
+					Default: int32default.StaticInt32(0),
 				},
 				"display": schema.BoolAttribute{
 					Description: "whether the GPU is presented as a display device to the guest VM",

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -237,6 +237,32 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 				},
 			},
 		},
+		"gpu": schema.SingleNestedAttribute{
+			Optional: true,
+			Attributes: map[string]schema.Attribute{
+				"vgpu_profile_id": schema.StringAttribute{
+					Description: "the ID of the vGPU profile to associate with the service offering",
+					Required:    true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"count": schema.Int32Attribute{
+					Description: "the number of GPUs to assign to the guest VM",
+					Optional:    true,
+					PlanModifiers: []planmodifier.Int32{
+						int32planmodifier.RequiresReplace(),
+					},
+				},
+				"display": schema.BoolAttribute{
+					Description: "whether the GPU is presented as a display device to the guest VM",
+					Optional:    true,
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+		},
 	}
 
 	for key, value := range s1 {

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -255,7 +255,7 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 					PlanModifiers: []planmodifier.Int32{
 						int32planmodifier.RequiresReplace(),
 					},
-					Default: int32default.StaticInt32(0),
+					Default: int32default.StaticInt32(1),
 				},
 				"display": schema.BoolAttribute{
 					Description: "whether the GPU is presented as a display device to the guest VM",

--- a/cloudstack/service_offering_schema.go
+++ b/cloudstack/service_offering_schema.go
@@ -250,6 +250,7 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 				"count": schema.Int32Attribute{
 					Description: "the number of GPUs to assign to the guest VM",
 					Optional:    true,
+					Computed:    true,
 					PlanModifiers: []planmodifier.Int32{
 						int32planmodifier.RequiresReplace(),
 					},
@@ -257,9 +258,11 @@ func serviceOfferingMergeCommonSchema(s1 map[string]schema.Attribute) map[string
 				"display": schema.BoolAttribute{
 					Description: "whether the GPU is presented as a display device to the guest VM",
 					Optional:    true,
+					Computed:    true,
 					PlanModifiers: []planmodifier.Bool{
 						boolplanmodifier.RequiresReplace(),
 					},
+					Default: booldefault.StaticBool(false),
 				},
 			},
 		},

--- a/cloudstack/service_offering_unconstrained_resource.go
+++ b/cloudstack/service_offering_unconstrained_resource.go
@@ -99,24 +99,8 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 
 func (r *serviceOfferingUnconstrainedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state serviceOfferingUnconstrainedResourceModel
-	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
-	var stateDiskOffering ServiceOfferingDiskOffering
-	var stateDiskQosStorage ServiceOfferingDiskQosStorage
-	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosHypervisor.As(ctx, &stateDiskQosHypervisor, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskOffering.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskOffering.As(ctx, &stateDiskOffering, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingDiskQosStorage.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
-	}
-	if !state.ServiceOfferingGpu.IsNull() {
-		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
-	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -130,11 +114,7 @@ func (r *serviceOfferingUnconstrainedResource) Read(ctx context.Context, req res
 		return
 	}
 
-	state.commonRead(ctx, cs)
-	stateDiskQosHypervisor.commonRead(ctx, cs)
-	stateDiskOffering.commonRead(ctx, cs)
-	stateDiskQosStorage.commonRead(ctx, cs)
-	stateGpu.commonRead(ctx, cs)
+	resp.Diagnostics.Append(state.commonRead(ctx, cs)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_unconstrained_resource.go
+++ b/cloudstack/service_offering_unconstrained_resource.go
@@ -55,6 +55,7 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 	var planDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var planDiskOffering ServiceOfferingDiskOffering
 	var planDiskQosStorage ServiceOfferingDiskQosStorage
+	var planGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if !plan.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -66,6 +67,9 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 	if !plan.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(plan.ServiceOfferingDiskQosStorage.As(ctx, &planDiskQosStorage, basetypes.ObjectAsOptions{})...)
 	}
+	if !plan.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(plan.ServiceOfferingGpu.As(ctx, &planGpu, basetypes.ObjectAsOptions{})...)
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -76,6 +80,7 @@ func (r *serviceOfferingUnconstrainedResource) Create(ctx context.Context, req r
 	planDiskQosHypervisor.commonCreateParams(ctx, params)
 	planDiskOffering.commonCreateParams(ctx, params)
 	planDiskQosStorage.commonCreateParams(ctx, params)
+	planGpu.commonCreateParams(ctx, params)
 
 	// create offering
 	cs, err := r.client.ServiceOffering.CreateServiceOffering(params)
@@ -97,6 +102,7 @@ func (r *serviceOfferingUnconstrainedResource) Read(ctx context.Context, req res
 	var stateDiskQosHypervisor ServiceOfferingDiskQosHypervisor
 	var stateDiskOffering ServiceOfferingDiskOffering
 	var stateDiskQosStorage ServiceOfferingDiskQosStorage
+	var stateGpu ServiceOfferingGpu
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
@@ -107,6 +113,9 @@ func (r *serviceOfferingUnconstrainedResource) Read(ctx context.Context, req res
 	}
 	if !state.ServiceOfferingDiskQosStorage.IsNull() {
 		resp.Diagnostics.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &stateDiskQosStorage, basetypes.ObjectAsOptions{})...)
+	}
+	if !state.ServiceOfferingGpu.IsNull() {
+		resp.Diagnostics.Append(state.ServiceOfferingGpu.As(ctx, &stateGpu, basetypes.ObjectAsOptions{})...)
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -125,6 +134,7 @@ func (r *serviceOfferingUnconstrainedResource) Read(ctx context.Context, req res
 	stateDiskQosHypervisor.commonRead(ctx, cs)
 	stateDiskOffering.commonRead(ctx, cs)
 	stateDiskQosStorage.commonRead(ctx, cs)
+	stateGpu.commonRead(ctx, cs)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/cloudstack/service_offering_unconstrained_resource_test.go
+++ b/cloudstack/service_offering_unconstrained_resource_test.go
@@ -228,7 +228,7 @@ const testAccServiceOfferingUnconstrained_gpu = `
 data "cloudstack_vgpu_profile" "test" {
 	filter {
 		name  = "name"
-		value = "passthrough"
+		value = "sim-8q"
 	}
 }
 

--- a/cloudstack/service_offering_unconstrained_resource_test.go
+++ b/cloudstack/service_offering_unconstrained_resource_test.go
@@ -79,7 +79,7 @@ func TestAccServiceOfferingUnconstrained_GPU(t *testing.T) {
 				Config: testAccServiceOfferingUnconstrained_gpu,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "name", "gpu"),
-					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttrPair("cloudstack_service_offering_unconstrained.gpu", "gpu.vgpu_profile_id", "data.cloudstack_vgpu_profile.test", "id"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.count", "1"),
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.display", "true"),
 				),
@@ -225,6 +225,13 @@ resource "cloudstack_service_offering_unconstrained" "disk_storage" {
 `
 
 const testAccServiceOfferingUnconstrained_gpu = `
+data "cloudstack_vgpu_profile" "test" {
+	filter {
+		name  = "name"
+		value = "passthrough"
+	}
+}
+
 resource "cloudstack_service_offering_unconstrained" "gpu" {
 	display_text = "gpu"
 	name         = "gpu"
@@ -239,7 +246,7 @@ resource "cloudstack_service_offering_unconstrained" "gpu" {
 	offer_ha                = true
 
 	gpu = {
-		vgpu_profile_id = "a6000-8a-profile"
+		vgpu_profile_id = data.cloudstack_vgpu_profile.test.id
 		count           = 1
 		display         = true
 	}

--- a/cloudstack/service_offering_unconstrained_resource_test.go
+++ b/cloudstack/service_offering_unconstrained_resource_test.go
@@ -66,6 +66,15 @@ func TestAccServiceOfferingUnconstrained(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.disk_storage", "name", "disk_storage"),
 				),
 			},
+			{
+				Config: testAccServiceOfferingUnconstrained_gpu,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "name", "gpu"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.vgpu_profile_id", "a6000-8a-profile"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.count", "1"),
+					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.gpu", "gpu.display", "true"),
+				),
+			},
 		},
 	})
 }
@@ -202,6 +211,28 @@ resource "cloudstack_service_offering_unconstrained" "disk_storage" {
 	disk_storage = {
 		min_iops = 100
 		max_iops = 100
+	}
+}
+`
+
+const testAccServiceOfferingUnconstrained_gpu = `
+resource "cloudstack_service_offering_unconstrained" "gpu" {
+	display_text = "gpu"
+	name         = "gpu"
+
+	host_tags = "test0101,test0202"
+	network_rate = 1024
+	deployment_planner = "UserDispersingPlanner"
+
+	dynamic_scaling_enabled = true
+	is_volatile             = true
+	limit_cpu_use           = true
+	offer_ha                = true
+
+	gpu = {
+		vgpu_profile_id = "a6000-8a-profile"
+		count           = 1
+		display         = true
 	}
 }
 `

--- a/cloudstack/service_offering_unconstrained_resource_test.go
+++ b/cloudstack/service_offering_unconstrained_resource_test.go
@@ -66,6 +66,15 @@ func TestAccServiceOfferingUnconstrained(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudstack_service_offering_unconstrained.disk_storage", "name", "disk_storage"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccServiceOfferingUnconstrained_GPU(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckGPU(t) },
+		ProtoV6ProviderFactories: testAccMuxProvider,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceOfferingUnconstrained_gpu,
 				Check: resource.ComposeTestCheckFunc(

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -215,11 +215,7 @@ func (state *ServiceOfferingGpu) commonRead(ctx context.Context, cs *cloudstack.
 	} else {
 		state.VgpuProfileId = types.StringNull()
 	}
-	if cs.Gpucount > 0 {
-		state.Count = types.Int32Value(int32(cs.Gpucount))
-	} else {
-		state.Count = types.Int32Null()
-	}
+	state.Count = types.Int32Value(int32(cs.Gpucount))
 	state.Display = types.BoolValue(cs.Gpudisplay)
 }
 

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -173,9 +173,13 @@ func (state *ServiceOfferingDiskQosStorage) commonRead(ctx context.Context, cs *
 func (state *ServiceOfferingGpu) commonRead(ctx context.Context, cs *cloudstack.ServiceOffering) {
 	if cs.Vgpuprofileid != "" {
 		state.VgpuProfileId = types.StringValue(cs.Vgpuprofileid)
+	} else {
+		state.VgpuProfileId = types.StringNull()
 	}
 	if cs.Gpucount > 0 {
 		state.Count = types.Int32Value(int32(cs.Gpucount))
+	} else {
+		state.Count = types.Int32Null()
 	}
 	state.Display = types.BoolValue(cs.Gpudisplay)
 }

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -170,6 +170,16 @@ func (state *ServiceOfferingDiskQosStorage) commonRead(ctx context.Context, cs *
 
 }
 
+func (state *ServiceOfferingGpu) commonRead(ctx context.Context, cs *cloudstack.ServiceOffering) {
+	if cs.Vgpuprofileid != "" {
+		state.VgpuProfileId = types.StringValue(cs.Vgpuprofileid)
+	}
+	if cs.Gpucount > 0 {
+		state.Count = types.Int32Value(int32(cs.Gpucount))
+	}
+	state.Display = types.BoolValue(cs.Gpudisplay)
+}
+
 // ------------------------------------------------------------------------------------------------------------------------------
 // common Create methods
 // -
@@ -274,6 +284,20 @@ func (plan *ServiceOfferingDiskQosStorage) commonCreateParams(ctx context.Contex
 	}
 	if !plan.MinIops.IsNull() {
 		p.SetMiniops((plan.MinIops.ValueInt64()))
+	}
+
+	return p
+}
+
+func (plan *ServiceOfferingGpu) commonCreateParams(ctx context.Context, p *cloudstack.CreateServiceOfferingParams) *cloudstack.CreateServiceOfferingParams {
+	if !plan.VgpuProfileId.IsNull() {
+		p.SetVgpuprofileid(plan.VgpuProfileId.ValueString())
+	}
+	if !plan.Count.IsNull() {
+		p.SetGpucount(int(plan.Count.ValueInt32()))
+	}
+	if !plan.Display.IsNull() {
+		p.SetGpudisplay(plan.Display.ValueBool())
 	}
 
 	return p

--- a/cloudstack/service_offering_util.go
+++ b/cloudstack/service_offering_util.go
@@ -22,7 +22,9 @@ import (
 	"strings"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 // ------------------------------------------------------------------------------------------------------------------------------
@@ -72,7 +74,9 @@ func (plan *serviceOfferingCommonResourceModel) commonUpdateParams(ctx context.C
 // ------------------------------------------------------------------------------------------------------------------------------
 // common Read methods
 // -
-func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context, cs *cloudstack.ServiceOffering) {
+func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context, cs *cloudstack.ServiceOffering) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	state.Id = types.StringValue(cs.Id)
 
 	if cs.Deploymentplanner != "" {
@@ -108,6 +112,41 @@ func (state *serviceOfferingCommonResourceModel) commonRead(ctx context.Context,
 	state.LimitCpuUse = types.BoolValue(cs.Limitcpuuse)
 	state.OfferHa = types.BoolValue(cs.Offerha)
 
+	// Refresh the nested blocks and encode them back into state so drift is detected
+	if !state.ServiceOfferingDiskQosHypervisor.IsNull() {
+		var v ServiceOfferingDiskQosHypervisor
+		diags.Append(state.ServiceOfferingDiskQosHypervisor.As(ctx, &v, basetypes.ObjectAsOptions{})...)
+		v.commonRead(ctx, cs)
+		obj, d := types.ObjectValueFrom(ctx, state.ServiceOfferingDiskQosHypervisor.AttributeTypes(ctx), v)
+		diags.Append(d...)
+		state.ServiceOfferingDiskQosHypervisor = obj
+	}
+	if !state.ServiceOfferingDiskOffering.IsNull() {
+		var v ServiceOfferingDiskOffering
+		diags.Append(state.ServiceOfferingDiskOffering.As(ctx, &v, basetypes.ObjectAsOptions{})...)
+		v.commonRead(ctx, cs)
+		obj, d := types.ObjectValueFrom(ctx, state.ServiceOfferingDiskOffering.AttributeTypes(ctx), v)
+		diags.Append(d...)
+		state.ServiceOfferingDiskOffering = obj
+	}
+	if !state.ServiceOfferingDiskQosStorage.IsNull() {
+		var v ServiceOfferingDiskQosStorage
+		diags.Append(state.ServiceOfferingDiskQosStorage.As(ctx, &v, basetypes.ObjectAsOptions{})...)
+		v.commonRead(ctx, cs)
+		obj, d := types.ObjectValueFrom(ctx, state.ServiceOfferingDiskQosStorage.AttributeTypes(ctx), v)
+		diags.Append(d...)
+		state.ServiceOfferingDiskQosStorage = obj
+	}
+	if !state.ServiceOfferingGpu.IsNull() {
+		var v ServiceOfferingGpu
+		diags.Append(state.ServiceOfferingGpu.As(ctx, &v, basetypes.ObjectAsOptions{})...)
+		v.commonRead(ctx, cs)
+		obj, d := types.ObjectValueFrom(ctx, state.ServiceOfferingGpu.AttributeTypes(ctx), v)
+		diags.Append(d...)
+		state.ServiceOfferingGpu = obj
+	}
+
+	return diags
 }
 
 func (state *ServiceOfferingDiskQosHypervisor) commonRead(ctx context.Context, cs *cloudstack.ServiceOffering) {

--- a/website/docs/d/gpu_card.html.markdown
+++ b/website/docs/d/gpu_card.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_gpu_card"
+description: |-
+  Gets information about a GPU card.
+---
+
+# cloudstack_gpu_card
+
+Use this data source to get information about a GPU card for use in other resources.
+
+## Example Usage
+
+```hcl
+data "cloudstack_gpu_card" "card" {
+  filter {
+    name = "name"
+    value = "NVIDIA.*"
+  }
+}
+
+output "gpu_card_id" {
+  value = data.cloudstack_gpu_card.card.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Required) One or more name/value pairs to filter off of. See detailed documentation below.
+
+### Filter Arguments
+
+* `name` - (Required) The name of the field to filter on. This can be any of the fields returned by the CloudStack API.
+* `value` - (Required) The value to filter on. This should be a regular expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the GPU card.
+* `name` - The name of the GPU card.
+* `device_id` - The device id of the GPU card.
+* `device_name` - The device name of the GPU card.
+* `vendor_id` - The vendor id of the GPU card.
+* `vendor_name` - The vendor name of the GPU card.

--- a/website/docs/d/gpu_card.html.markdown
+++ b/website/docs/d/gpu_card.html.markdown
@@ -14,8 +14,8 @@ Use this data source to get information about a GPU card for use in other resour
 ```hcl
 data "cloudstack_gpu_card" "card" {
   filter {
-    name = "name"
-    value = "NVIDIA.*"
+    name  = "keyword"
+    value = "NVIDIA"
   }
 }
 
@@ -32,8 +32,12 @@ The following arguments are supported:
 
 ### Filter Arguments
 
-* `name` - (Required) The name of the field to filter on. This can be any of the fields returned by the CloudStack API.
-* `value` - (Required) The value to filter on. This should be a regular expression.
+* `name` - (Required) The name of the field to filter on. Filtering is performed server-side by the
+  CloudStack API. Supported values are `id`, `device_id`, `device_name`, `vendor_id`, `vendor_name`,
+  `keyword`, and `active_only`.
+* `value` - (Required) The value to filter on. This is passed directly to the CloudStack API and
+  matched exactly (not as a regular expression). The filters must narrow the result to a single GPU
+  card; if more than one card matches, an error is returned.
 
 ## Attributes Reference
 

--- a/website/docs/d/vgpu_profile.html.markdown
+++ b/website/docs/d/vgpu_profile.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "cloudstack"
+page_title: "CloudStack: cloudstack_vgpu_profile"
+description: |-
+  Gets information about a vGPU profile.
+---
+
+# cloudstack_vgpu_profile
+
+Use this data source to get information about a vGPU profile for use in other resources.
+
+## Example Usage
+
+```hcl
+data "cloudstack_vgpu_profile" "profile" {
+  filter {
+    name = "name"
+    value = "passthrough"
+  }
+}
+
+output "vgpu_profile_id" {
+  value = data.cloudstack_vgpu_profile.profile.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Required) One or more name/value pairs to filter off of. See detailed documentation below.
+
+### Filter Arguments
+
+* `name` - (Required) The name of the field to filter on. This can be any of the fields returned by the CloudStack API.
+* `value` - (Required) The value to filter on. This should be a regular expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the vGPU profile.
+* `name` - The name of the vGPU profile.
+* `description` - The description of the vGPU profile.
+* `device_id` - The device id of the GPU card.
+* `device_name` - The device name of the GPU card.
+* `gpu_card_id` - The GPU card id of the vGPU profile.
+* `gpu_card_name` - The GPU card name of the vGPU profile.
+* `max_heads` - The maximum displays per vGPU instance.
+* `max_resolution_x` - The maximum X resolution per display.
+* `max_resolution_y` - The maximum Y resolution per display.
+* `max_vgpu_per_physical_gpu` - The maximum number of vGPU instances per physical GPU.
+* `vendor_id` - The vendor id of the GPU card.
+* `vendor_name` - The vendor name of the GPU card.
+* `video_ram` - The video RAM size in MB for the vGPU profile.

--- a/website/docs/d/vgpu_profile.html.markdown
+++ b/website/docs/d/vgpu_profile.html.markdown
@@ -32,8 +32,11 @@ The following arguments are supported:
 
 ### Filter Arguments
 
-* `name` - (Required) The name of the field to filter on. This can be any of the fields returned by the CloudStack API.
-* `value` - (Required) The value to filter on. This should be a regular expression.
+* `name` - (Required) The name of the field to filter on. Filtering is performed server-side by the
+  CloudStack API. Supported values are `id`, `name`, `gpu_card_id`, `keyword`, and `active_only`.
+* `value` - (Required) The value to filter on. This is passed directly to the CloudStack API and
+  matched exactly (not as a regular expression). The filters must narrow the result to a single
+  vGPU profile; if more than one profile matches, an error is returned.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_offering_constrained.html.markdown
+++ b/website/docs/r/service_offering_constrained.html.markdown
@@ -37,6 +37,12 @@ resource "cloudstack_service_offering_constrained" "example" {
 		provisioning_type         = "thin"
 		storage_type              = "local"
 	}
+
+	gpu {
+		vgpu_profile_id = "gpu-profile-uuid"
+		count           = 1
+		display         = false
+	}
 }
 ```
 
@@ -88,6 +94,12 @@ The following arguments are supported:
 - `hypervisor_snapshot_reserve` (Int, Optional) - Hypervisor snapshot reserve space as a percent of a volume (for managed storage using Xen or VMware).
 - `max_iops` (Int, Optional) - Max IOPS of the compute offering.
 - `min_iops` (Int, Optional) - Min IOPS of the compute offering.
+
+#### `gpu` (Block, Optional)
+
+- `vgpu_profile_id` (String, Required) - The ID of the vGPU profile to associate with the service offering.
+- `count` (Int, Optional, Computed) - The number of GPUs to assign to the guest VM.
+- `display` (Bool, Optional, Computed, Default: false) - Whether the GPU is presented as a display device to the guest VM.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_offering_fixed.html.markdown
+++ b/website/docs/r/service_offering_fixed.html.markdown
@@ -32,6 +32,11 @@ resource "cloudstack_service_offering_fixed" "fixed1" {
   # disk_offering { ... }
   # disk_hypervisor { ... }
   # disk_storage { ... }
+  # gpu {
+  #   vgpu_profile_id = "..."
+  #   count           = 1
+  #   display         = false
+  # }
 }
 ```
 
@@ -85,6 +90,12 @@ The following arguments are supported:
 - `hypervisor_snapshot_reserve` (Optional) - Hypervisor snapshot reserve space as a percent of a volume.
 - `max_iops` (Optional) - Max IOPS of the compute offering.
 - `min_iops` (Optional) - Min IOPS of the compute offering.
+
+#### `gpu` (Optional)
+
+- `vgpu_profile_id` (Required) - The ID of the vGPU profile to associate with the service offering.
+- `count` (Optional, Computed) - The number of GPUs to assign to the guest VM.
+- `display` (Optional, Computed) - Whether the GPU is presented as a display device to the guest VM. Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_offering_unconstrained.html.markdown
+++ b/website/docs/r/service_offering_unconstrained.html.markdown
@@ -29,6 +29,11 @@ resource "cloudstack_service_offering_unconstrained" "unconstrained1" {
   # disk_offering { ... }
   # disk_hypervisor { ... }
   # disk_storage { ... }
+  # gpu {
+  #   vgpu_profile_id = "..."
+  #   count           = 1
+  #   display         = false
+  # }
 }
 ```
 
@@ -79,6 +84,12 @@ The following arguments are supported:
 - `hypervisor_snapshot_reserve` (Optional) - Hypervisor snapshot reserve space as a percent of a volume.
 - `max_iops` (Optional) - Max IOPS of the compute offering.
 - `min_iops` (Optional) - Min IOPS of the compute offering.
+
+#### `gpu` (Optional)
+
+- `vgpu_profile_id` (Required) - The ID of the vGPU profile to associate with the service offering.
+- `count` (Optional, Computed) - The number of GPUs to assign to the guest VM.
+- `display` (Optional, Computed) - Whether the GPU is presented as a display device to the guest VM. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

Adds GPU support to the provider, aligned with the GPU/vGPU APIs introduced in
recent CloudStack releases. This lets operators discover GPU cards and vGPU
profiles and attach GPUs to service offerings.

## What's included

**New data sources**
- `cloudstack_gpu_card` — looks up a GPU card via the `listGpuCards` API.
  Exposes `id`, `name`, `device_id`, `device_name`, `vendor_id`, `vendor_name`.
- `cloudstack_vgpu_profile` — looks up a vGPU profile via the `listVgpuProfiles`
  API. Exposes `id`, `name`, `description`, `device_id`, `device_name`,
  `gpu_card_id`, `gpu_card_name`, `max_heads`, `max_resolution_x`,
  `max_resolution_y`, `max_vgpu_per_physical_gpu`, `vendor_id`, `vendor_name`,
  `video_ram`.

  Both data sources support the standard `filter` block (regex matching on
  returned fields).

**Service offering GPU configuration**
- Adds an optional `gpu` nested block to the service offering resources
  (constrained / fixed / unconstrained), with:
  - `vgpu_profile_id` (required) — vGPU profile to associate with the offering
  - `count` (optional) — number of GPUs assigned to the guest VM
  - `display` (optional) — whether the GPU is presented as a display device
  - All three force replacement when changed.

**Docs**
- Website documentation for `gpu_card` and `vgpu_profile` data sources.

**Dependency**
- Bumps `github.com/apache/cloudstack-go/v2` from `v2.18.1` to `v2.19.1` for the
  GPU API bindings.

## Example usage

```hcl
data "cloudstack_gpu_card" "main" {
  filter {
    name  = "name"
    value = "Example Corp EX100GL \\[ExampleGPU 32GB\\]"
  }
}

data "cloudstack_vgpu_profile" "main" {
  filter {
    name  = "gpu_card_id"
    value = data.cloudstack_gpu_card.main.id
  }
  filter {
    name  = "name"
    value = "passthrough"
  }
}

resource "cloudstack_service_offering_constrained" "example" {
  name         = "example.gpu.offering"
  display_text = "Example GPU offering, vCPU 2-32, Memory 2G-128G"

  // compute
  cpu_speed      = 1024
  max_cpu_number = 32
  min_cpu_number = 2
  max_memory     = 131072
  min_memory     = 2048
  network_rate   = 10000

  // other
  disk_offering_id = var.disk_offering_id
  zone_ids         = var.zone_ids
  tags             = "EXAMPLE_STORAGE"
  host_tags        = "EXAMPLE_GPU"

  // Feature flags
  dynamic_scaling_enabled = true
  is_volatile             = false
  limit_cpu_use           = false
  offer_ha                = true

  gpu = {
    vgpu_profile_id = data.cloudstack_vgpu_profile.main.id
    count           = 1
    display         = true
  }
}
```