### PR TITLE
Fix cloudstack_instance data source ignoring project

### DIFF
--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -48,6 +48,12 @@ func dataSourceCloudstackInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"project": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
 			"display_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -98,6 +104,12 @@ func dataSourceCloudstackInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	cs := meta.(*cloudstack.CloudStackClient)
 	p := cs.VirtualMachine.NewListVirtualMachinesParams()
+
+	// If there is a project supplied, we retrieve and set the project id
+	if err := setProjectid(p, cs, d); err != nil {
+		return err
+	}
+
 	csInstances, err := cs.VirtualMachine.ListVirtualMachines(p)
 
 	if err != nil {
@@ -148,6 +160,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *cloudstack.
 	d.SetId(instance.Id)
 	d.Set("instance_id", instance.Id)
 	d.Set("account", instance.Account)
+	d.Set("project", instance.Project)
 	d.Set("created", instance.Created)
 	d.Set("display_name", instance.Displayname)
 	d.Set("state", instance.State)

--- a/cloudstack/data_source_cloudstack_instance_test.go
+++ b/cloudstack/data_source_cloudstack_instance_test.go
@@ -54,11 +54,65 @@ const testAccInstanceDataSourceConfig_basic = `
 	  }
 	  data "cloudstack_instance" "my_instance_test" {
 		filter {
-		name = "display_name" 
+		name = "display_name"
 		value = "server-a"
 	  }
 		depends_on = [
 		cloudstack_instance.my_instance
 	  ]
+	}
+`
+
+// regression test for https://github.com/apache/cloudstack-terraform-provider/issues/266 :
+// instances deployed inside a project were never returned by the data source because
+// ListVirtualMachines was called without a projectid, so the filter had nothing to match.
+func TestAccInstanceDataSource_project(t *testing.T) {
+	resourceName := "cloudstack_instance.my_project_instance"
+	datasourceName := "data.cloudstack_instance.my_project_instance_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceDataSourceConfig_project,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "display_name", resourceName, "display_name"),
+					resource.TestCheckResourceAttr(datasourceName, "project", "terraform"),
+				),
+			},
+		},
+	})
+}
+
+const testAccInstanceDataSourceConfig_project = `
+	resource "cloudstack_network" "my_project_network" {
+		name              = "terraform-datasource-network"
+		display_text      = "terraform-datasource-network"
+		cidr              = "10.1.2.0/24"
+		network_offering  = "DefaultIsolatedNetworkOfferingWithSourceNatService"
+		project           = "terraform"
+		zone              = "Sandbox-simulator"
+	}
+
+	resource "cloudstack_instance" "my_project_instance" {
+		name             = "server-b"
+		service_offering = "Small Instance"
+		template         = "CentOS 5.6 (64-bit) no GUI (Simulator)"
+		network_id       = cloudstack_network.my_project_network.id
+		zone             = cloudstack_network.my_project_network.zone
+		project          = "terraform"
+		expunge          = true
+	}
+
+	data "cloudstack_instance" "my_project_instance_test" {
+		project = "terraform"
+		filter {
+			name  = "display_name"
+			value = "server-b"
+		}
+		depends_on = [
+			cloudstack_instance.my_project_instance
+		]
 	}
 `

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -28,6 +28,7 @@ data "cloudstack_instance" "my_instance" {
 ### Argument Reference
 
 * `filter` - (Required) One or more name/value pairs to filter off of. You can apply filters on any exported attributes.
+* `project` - (Optional) The name or ID of the project the instance is deployed in. Required to find instances that belong to a project.
 
 ## Attributes Reference
 
@@ -35,6 +36,7 @@ The following attributes are exported:
 
 * `instance_id` - The ID of the virtual machine.
 * `account` - The account associated with the virtual machine.
+* `project` - The project the virtual machine is associated with.
 * `display_name` - The user generated name. The name of the virtual machine is returned if no displayname exists.
 * `state` - The state of the virtual machine.
 * `host_id` - The ID of the host for the virtual machine.


### PR DESCRIPTION
## What
`data.cloudstack_instance` couldn't find instances deployed inside a project. It always failed with `No instance is matching with the specified regex`, even when the instance clearly existed.

## Why
The data source called `ListVirtualMachines` without a `projectid`, so project-scoped instances never showed up in the list, and the filter had nothing to match. The error message just didn't say why.

## Fix
Added a `project` argument to the data source and pass it through with the same `setProjectid` helper the VPC data source already uses. Also set `project` on the result so it's exported like the other attributes.

## Testing
Ran against the CloudStack simulator:
- New `TestAccInstanceDataSource_project` reproduces the bug and confirms the fix
- Existing `TestAccInstanceDataSource_basic` and the full `TestAccCloudStackInstance_*` suite still pass
- `go build`, `go vet`, `gofmt` all clean

Fixes #266