### PR TITLE
Add externalloadbalanceripaddress and enablecsi to kubernetes_cluster resource

### DIFF
--- a/cloudstack/resource_cloudstack_kubernetes_cluster.go
+++ b/cloudstack/resource_cloudstack_kubernetes_cluster.go
@@ -214,6 +214,20 @@ func resourceCloudStackKubernetesCluster() *schema.Resource {
 				ForceNew:    true,
 				Description: "An optional map of node roles to instance templates. If not specified, system VM template will be used. Valid roles are: worker, control, etcd",
 			},
+
+			"externalloadbalanceripaddress": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The external load balancer IP address for HA clusters (multiple control nodes) on Shared networks",
+			},
+
+			"enablecsi": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Enable CloudStack CSI (Container Storage Interface) for the Kubernetes cluster",
+			},
 		},
 	}
 }
@@ -340,6 +354,14 @@ func resourceCloudStackKubernetesClusterCreate(d *schema.ResourceData, meta inte
 		p.SetCniconfigdetails(cniConfigDetailsFormatted)
 	}
 
+	if externalLoadBalancerIPAddress, ok := d.GetOk("externalloadbalanceripaddress"); ok {
+		p.SetExternalloadbalanceripaddress(externalLoadBalancerIPAddress.(string))
+	}
+
+	if enableCSI, ok := d.GetOk("enablecsi"); ok {
+		p.SetEnablecsi(enableCSI.(bool))
+	}
+
 	log.Printf("[DEBUG] Creating Kubernetes Cluster %s", name)
 	r, err := cs.Kubernetes.CreateKubernetesCluster(p)
 	if err != nil {
@@ -410,6 +432,8 @@ func resourceCloudStackKubernetesClusterRead(d *schema.ResourceData, meta interf
 
 	d.Set("etcd_nodes_size", cluster.Etcdnodes)
 	d.Set("cni_configuration_id", cluster.Cniconfigurationid)
+	d.Set("externalloadbalanceripaddress", cluster.Externalloadbalanceripaddress)
+	d.Set("enablecsi", cluster.Enablecsi)
 
 	setValueOrID(d, "kubernetes_version", cluster.Kubernetesversionname, cluster.Kubernetesversionid)
 	setValueOrID(d, "service_offering", cluster.Serviceofferingname, cluster.Serviceofferingid)

--- a/cloudstack/resource_cloudstack_kubernetes_cluster.go
+++ b/cloudstack/resource_cloudstack_kubernetes_cluster.go
@@ -215,14 +215,14 @@ func resourceCloudStackKubernetesCluster() *schema.Resource {
 				Description: "An optional map of node roles to instance templates. If not specified, system VM template will be used. Valid roles are: worker, control, etcd",
 			},
 
-			"externalloadbalanceripaddress": {
+			"external_load_balancer_ip_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The external load balancer IP address for HA clusters (multiple control nodes) on Shared networks",
 			},
 
-			"enablecsi": {
+			"enable_csi": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
@@ -354,11 +354,11 @@ func resourceCloudStackKubernetesClusterCreate(d *schema.ResourceData, meta inte
 		p.SetCniconfigdetails(cniConfigDetailsFormatted)
 	}
 
-	if externalLoadBalancerIPAddress, ok := d.GetOk("externalloadbalanceripaddress"); ok {
+	if externalLoadBalancerIPAddress, ok := d.GetOk("external_load_balancer_ip_address"); ok {
 		p.SetExternalloadbalanceripaddress(externalLoadBalancerIPAddress.(string))
 	}
 
-	if enableCSI, ok := d.GetOk("enablecsi"); ok {
+	if enableCSI, ok := d.GetOkExists("enable_csi"); ok {
 		p.SetEnablecsi(enableCSI.(bool))
 	}
 
@@ -432,8 +432,8 @@ func resourceCloudStackKubernetesClusterRead(d *schema.ResourceData, meta interf
 
 	d.Set("etcd_nodes_size", cluster.Etcdnodes)
 	d.Set("cni_configuration_id", cluster.Cniconfigurationid)
-	d.Set("externalloadbalanceripaddress", cluster.Externalloadbalanceripaddress)
-	d.Set("enablecsi", cluster.Enablecsi)
+	d.Set("external_load_balancer_ip_address", cluster.Externalloadbalanceripaddress)
+	d.Set("enable_csi", cluster.Enablecsi)
 
 	setValueOrID(d, "kubernetes_version", cluster.Kubernetesversionname, cluster.Kubernetesversionid)
 	setValueOrID(d, "service_offering", cluster.Serviceofferingname, cluster.Serviceofferingid)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@
 module github.com/terraform-providers/terraform-provider-cloudstack
 
 require (
-	github.com/apache/cloudstack-go/v2 v2.19.1
+	github.com/apache/cloudstack-go/v2 v2.20.0
 	github.com/go-ini/ini v1.67.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-framework v1.12.0


### PR DESCRIPTION
Adds support for two missing parameters in the cloudstack_kubernetes_cluster Terraform resource.

**NOTE:** Merge this after the cloudstack-go PR (and tag updated in the terraform) - https://github.com/apache/cloudstack-go/pull/163