### PR TITLE
Add VR address parameter to network

### DIFF
--- a/cloudstack/resource_cloudstack_network.go
+++ b/cloudstack/resource_cloudstack_network.go
@@ -120,6 +120,18 @@ func resourceCloudStackNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"routerip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"routeripv6": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"startip": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -291,6 +303,14 @@ func resourceCloudStackNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		if endipv6, ok := m6["endipv6"]; ok {
 			p.SetEndipv6(endipv6)
 		}
+	}
+
+	if routerip, ok := d.GetOk("routerip"); ok {
+		p.SetRouterip(routerip.(string))
+	}
+
+	if routeripv6, ok := d.GetOk("routeripv6"); ok {
+		p.SetRouteripv6(routeripv6.(string))
 	}
 
 	// Set the network domain if we have one

--- a/cloudstack/resource_cloudstack_network_test.go
+++ b/cloudstack/resource_cloudstack_network_test.go
@@ -285,6 +285,27 @@ func TestAccCloudStackNetwork_ipv6_custom_gateway(t *testing.T) {
 	})
 }
 
+func TestAccCloudStackNetwork_routerIPs(t *testing.T) {
+	var network cloudstack.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackNetwork_routerIPs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackNetworkExists(
+						"cloudstack_network.router_ips", &network),
+					resource.TestCheckResourceAttr(
+						"cloudstack_network.router_ips", "routerip", "10.20.0.2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudStackNetworkExists(
 	n string, network *cloudstack.Network) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -631,6 +652,38 @@ resource "cloudstack_network" "foo" {
   ip6gateway = "2001:db8:2::1"
   network_offering = "DefaultIsolatedNetworkOfferingWithSourceNatService"
   zone = "Sandbox-simulator"
+}`
+
+const testAccCloudStackNetwork_routerIPs = `
+resource "cloudstack_network_offering" "router_ips" {
+  name                = "terraform-router-ip-network-offering"
+  display_text        = "Terraform Router IP Network Offering"
+  guest_ip_type       = "Shared"
+  traffic_type        = "Guest"
+  network_rate        = 200
+  conserve_mode       = true
+  enable              = true
+  specify_vlan        = true
+  specify_ip_ranges   = true
+  supported_services  = ["Dhcp", "Dns", "UserData"]
+  service_provider_list = {
+    Dhcp     = "VirtualRouter"
+    Dns      = "VirtualRouter"
+    UserData = "VirtualRouter"
+  }
+}
+
+resource "cloudstack_network" "router_ips" {
+  name             = "terraform-router-ip-network"
+  display_text     = "terraform-router-ip-network"
+  cidr             = "10.20.0.0/24"
+  gateway          = "10.20.0.1"
+  startip          = "10.20.0.2"
+  endip            = "10.20.0.250"
+  routerip         = "10.20.0.2"
+  network_offering = cloudstack_network_offering.router_ips.id
+  zone             = "Sandbox-simulator"
+  vlan             = 300
 }`
 
 const testAccCloudStackNetwork_vpcProjectInheritance = `

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -23,14 +23,20 @@ resource "cloudstack_network" "default" {
 }
 ```
 
-With IPv6 support:
+Shared network with explicit IPv4 and IPv6 router addresses:
 
 ```hcl
-resource "cloudstack_network" "ipv6" {
+resource "cloudstack_network" "shared" {
   name             = "test-network-ipv6"
   cidr             = "10.0.0.0/16"
+  startip          = "10.0.0.2"
+  endip            = "10.0.255.254"
   ip6cidr          = "2001:db8::/64"
-  network_offering = "Default Network"
+  startipv6        = "2001:db8::2"
+  endipv6          = "2001:db8::ffff"
+  routerip         = "10.0.0.2"
+  routeripv6       = "2001:db8::2"
+  network_offering = "Shared Network Offering"
   zone             = "zone-1"
 }
 ```
@@ -85,6 +91,14 @@ The following arguments are supported:
 * `ip6gateway` - (Optional) IPv6 Gateway that will be provided to the instances
     in this network. Must fall within `ip6cidr`. Defaults to the second address
     in the subnet (network address + 1, e.g., 2001:db8::1 for 2001:db8::/64).
+
+* `routerip` - (Optional) IPv4 address to assign to the router in a shared
+    network. Requires CloudStack 4.16 or later. Changing this forces a new
+    resource to be created.
+
+* `routeripv6` - (Optional) IPv6 address to assign to the router in a shared
+    network. Requires CloudStack 4.16 or later. Changing this forces a new
+    resource to be created.
 
 * `startipv6` - (Optional) Start of the IPv6 block that will be available on the
     network. Must fall within `ip6cidr`. Only applied when the network offering


### PR DESCRIPTION
Allow setting a specific router IP or IPv6 address on a `cloudstack_network` using `routerip` and `routeripv6` respectively. Adjusted the example to showcase both cases.