### PR TITLE
Fix private gateway ACL update using wrong SDK setter

### DIFF
--- a/cloudstack/resource_cloudstack_private_gateway.go
+++ b/cloudstack/resource_cloudstack_private_gateway.go
@@ -172,7 +172,7 @@ func resourceCloudStackPrivateGatewayUpdate(d *schema.ResourceData, meta interfa
 	// Replace the ACL if the ID has changed
 	if d.HasChange("acl_id") {
 		p := cs.NetworkACL.NewReplaceNetworkACLListParams(d.Get("acl_id").(string))
-		p.SetNetworkid(d.Id())
+		p.SetGatewayid(d.Id())
 
 		_, err := cs.NetworkACL.ReplaceNetworkACLList(p)
 		if err != nil {


### PR DESCRIPTION
resourceCloudStackPrivateGatewayUpdate called SetNetworkid with the private gateway's own ID instead of SetGatewayid, so any acl_id update was rejected by the API with "entity does not exist". Use SetGatewayid, matching ReplaceNetworkACLListParams' actual parameter for updating a private gateway's ACL.