### PR TITLE
fix: make network offering update work (set the id) and read back correctly

### DIFF
--- a/cloudstack/resource_cloudstack_network_offering.go
+++ b/cloudstack/resource_cloudstack_network_offering.go
@@ -259,6 +259,9 @@ func resourceCloudStackNetworkOfferingUpdate(d *schema.ResourceData, meta interf
 		// Create a new parameter struct
 		p := cs.NetworkOffering.NewUpdateNetworkOfferingParams()
 
+		// Target this network offering
+		p.SetId(d.Id())
+
 		// Set the new name
 		p.SetName(d.Get("name").(string))
 
@@ -277,6 +280,9 @@ func resourceCloudStackNetworkOfferingUpdate(d *schema.ResourceData, meta interf
 
 		// Create a new parameter struct
 		p := cs.NetworkOffering.NewUpdateNetworkOfferingParams()
+
+		// Target this network offering
+		p.SetId(d.Id())
 
 		// Set the new display text
 		p.SetDisplaytext(d.Get("display_text").(string))
@@ -297,6 +303,9 @@ func resourceCloudStackNetworkOfferingUpdate(d *schema.ResourceData, meta interf
 		// Create a new parameter struct
 		p := cs.NetworkOffering.NewUpdateNetworkOfferingParams()
 
+		// Target this network offering
+		p.SetId(d.Id())
+
 		// Set the new max connections
 		p.SetMaxconnections(d.Get("max_connections").(int))
 
@@ -316,19 +325,22 @@ func resourceCloudStackNetworkOfferingUpdate(d *schema.ResourceData, meta interf
 		// Create a new parameter struct
 		p := cs.NetworkOffering.NewUpdateNetworkOfferingParams()
 
+		// Target this network offering
+		p.SetId(d.Id())
+
 		// Set the new domain id
 		p.SetDomainid(d.Get("domain_id").(string))
 
-		// Update the traffic type
+		// Update the domain id
 		_, err := cs.NetworkOffering.UpdateNetworkOffering(p)
 		if err != nil {
 			return fmt.Errorf(
-				"Error updating the traffic type for network offering %s: %s", name, err)
+				"Error updating the domain id for network offering %s: %s", name, err)
 		}
 
 	}
 
-	return resourceCloudStackInstanceRead(d, meta)
+	return resourceCloudStackNetworkOfferingRead(d, meta)
 }
 
 func resourceCloudStackNetworkOfferingDelete(d *schema.ResourceData, meta interface{}) error {

--- a/cloudstack/resource_cloudstack_network_offering_test.go
+++ b/cloudstack/resource_cloudstack_network_offering_test.go
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cloudstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccCloudStackNetworkOffering_update creates a network offering and then updates its
+// display_text in a second step, exercising resourceCloudStackNetworkOfferingUpdate. It guards
+// against the update reading state back through the wrong resource's Read function.
+func TestAccCloudStackNetworkOffering_update(t *testing.T) {
+	name := "tf-acc-no-" + resource.UniqueId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackNetworkOfferingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkOfferingUpdateConfig(name, "display text one"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_network_offering.foo", "name", name),
+					resource.TestCheckResourceAttr("cloudstack_network_offering.foo", "display_text", "display text one"),
+				),
+			},
+			{
+				Config: testAccNetworkOfferingUpdateConfig(name, "display text two"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudstack_network_offering.foo", "name", name),
+					resource.TestCheckResourceAttr("cloudstack_network_offering.foo", "display_text", "display text two"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkOfferingUpdateConfig(name, displayText string) string {
+	return fmt.Sprintf(`
+resource "cloudstack_network_offering" "foo" {
+  name          = "%s"
+  display_text  = "%s"
+  guest_ip_type = "Isolated"
+  traffic_type  = "Guest"
+}
+`, name, displayText)
+}
+
+func testAccCheckCloudStackNetworkOfferingDestroy(s *terraform.State) error {
+	cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudstack_network_offering" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No network offering ID is set")
+		}
+
+		_, _, err := cs.NetworkOffering.GetNetworkOfferingByID(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Network offering %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description

`resourceCloudStackNetworkOfferingUpdate` was broken in two ways, and updating a `cloudstack_network_offering` failed outright:

1. Each `UpdateNetworkOffering` call built its params with `NewUpdateNetworkOfferingParams()` but never set the offering id, so every update (name, display_text, max_connections, domain_id) failed with:

        CloudStack API error 530 (CSExceptionErrorCode: 9999): Cannot invoke
        "java.lang.Long.longValue()" because "id" is null

   Fixed by setting the id on each params struct.

2. After updating, the function returned `resourceCloudStackInstanceRead`, the read function for the `cloudstack_instance` resource, which looks up a VM by the network offering id and corrupts the resource state. Fixed to return `resourceCloudStackNetworkOfferingRead`, matching the Create and Read paths.

### Testing

Added an acceptance test `TestAccCloudStackNetworkOffering_update` that creates a network offering and then updates its `display_text`. It fails before this change (the `id is null` API error) and passes after.

Verified end to end against a live CloudStack advanced zone:

        TF_ACC=1 go test ./cloudstack/ -run TestAccCloudStackNetworkOffering_update
        --- PASS: TestAccCloudStackNetworkOffering_update

`go build ./...`, `go vet ./...`, and the unit suite (`go test ./cloudstack/`) also pass.
