### PR TITLE
Increase timeout for acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 30m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 45m
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
The current GitHub actions runners cannot keep up with the 30 minute timeout. It's a hit or miss whether it completes within time or not. Upping this to 45 minutes (or something in between if there are objections) should make results a bit more predictive.