### PR TITLE
fix: prevent data source filter panics on unknown or non-string fields

### DIFF
--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -207,7 +207,7 @@ func applyInstanceFilters(instance *cloudstack.VirtualMachine, filters *schema.S
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		instanceField := instanceJSON[updatedName].(string)
+		instanceField := fmt.Sprintf("%v", instanceJSON[updatedName])
 		if !r.MatchString(instanceField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_instance.go
+++ b/cloudstack/data_source_cloudstack_instance.go
@@ -207,7 +207,11 @@ func applyInstanceFilters(instance *cloudstack.VirtualMachine, filters *schema.S
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		instanceField := fmt.Sprintf("%v", instanceJSON[updatedName])
+		instanceFieldValue, instanceFieldFound := instanceJSON[updatedName]
+		if !instanceFieldFound || instanceFieldValue == nil {
+			return false, nil
+		}
+		instanceField := fmt.Sprintf("%v", instanceFieldValue)
 		if !r.MatchString(instanceField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_ipaddress.go
+++ b/cloudstack/data_source_cloudstack_ipaddress.go
@@ -165,7 +165,11 @@ func applyIPAddressFilters(publicIpAddress *cloudstack.PublicIpAddress, filters 
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		publicIPAdressField := fmt.Sprintf("%v", publicIPAdressJSON[updatedName])
+		publicIPAdressFieldValue, publicIPAdressFieldFound := publicIPAdressJSON[updatedName]
+		if !publicIPAdressFieldFound || publicIPAdressFieldValue == nil {
+			return false, nil
+		}
+		publicIPAdressField := fmt.Sprintf("%v", publicIPAdressFieldValue)
 		if !r.MatchString(publicIPAdressField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_network_offering.go
+++ b/cloudstack/data_source_cloudstack_network_offering.go
@@ -245,7 +245,7 @@ func applyNetworkOfferingFilters(networkOffering *cloudstack.NetworkOffering, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		networkOfferingField := networkOfferingJSON[updatedName].(string)
+		networkOfferingField := fmt.Sprintf("%v", networkOfferingJSON[updatedName])
 		if !r.MatchString(networkOfferingField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_network_offering.go
+++ b/cloudstack/data_source_cloudstack_network_offering.go
@@ -245,7 +245,11 @@ func applyNetworkOfferingFilters(networkOffering *cloudstack.NetworkOffering, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		networkOfferingField := fmt.Sprintf("%v", networkOfferingJSON[updatedName])
+		networkOfferingFieldValue, networkOfferingFieldFound := networkOfferingJSON[updatedName]
+		if !networkOfferingFieldFound || networkOfferingFieldValue == nil {
+			return false, nil
+		}
+		networkOfferingField := fmt.Sprintf("%v", networkOfferingFieldValue)
 		if !r.MatchString(networkOfferingField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_physical_network.go
+++ b/cloudstack/data_source_cloudstack_physical_network.go
@@ -131,7 +131,7 @@ func applyPhysicalNetworkFilters(physicalNetwork *cloudstack.PhysicalNetwork, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		physicalNetworkField := physicalNetworkJSON[updatedName].(string)
+		physicalNetworkField := fmt.Sprintf("%v", physicalNetworkJSON[updatedName])
 		if !r.MatchString(physicalNetworkField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_physical_network.go
+++ b/cloudstack/data_source_cloudstack_physical_network.go
@@ -131,7 +131,11 @@ func applyPhysicalNetworkFilters(physicalNetwork *cloudstack.PhysicalNetwork, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		physicalNetworkField := fmt.Sprintf("%v", physicalNetworkJSON[updatedName])
+		physicalNetworkFieldValue, physicalNetworkFieldFound := physicalNetworkJSON[updatedName]
+		if !physicalNetworkFieldFound || physicalNetworkFieldValue == nil {
+			return false, nil
+		}
+		physicalNetworkField := fmt.Sprintf("%v", physicalNetworkFieldValue)
 		if !r.MatchString(physicalNetworkField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_service_offering.go
+++ b/cloudstack/data_source_cloudstack_service_offering.go
@@ -128,7 +128,7 @@ func applyServiceOfferingFilters(serviceOffering *cloudstack.ServiceOffering, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		serviceOfferingField := serviceOfferingJSON[updatedName].(string)
+		serviceOfferingField := fmt.Sprintf("%v", serviceOfferingJSON[updatedName])
 		if !r.MatchString(serviceOfferingField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_service_offering.go
+++ b/cloudstack/data_source_cloudstack_service_offering.go
@@ -128,7 +128,11 @@ func applyServiceOfferingFilters(serviceOffering *cloudstack.ServiceOffering, fi
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		serviceOfferingField := fmt.Sprintf("%v", serviceOfferingJSON[updatedName])
+		serviceOfferingFieldValue, serviceOfferingFieldFound := serviceOfferingJSON[updatedName]
+		if !serviceOfferingFieldFound || serviceOfferingFieldValue == nil {
+			return false, nil
+		}
+		serviceOfferingField := fmt.Sprintf("%v", serviceOfferingFieldValue)
 		if !r.MatchString(serviceOfferingField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_ssh_keypair.go
+++ b/cloudstack/data_source_cloudstack_ssh_keypair.go
@@ -103,7 +103,7 @@ func applySshKeyPairsFilters(sshKeyPair *cloudstack.SSHKeyPair, filters *schema.
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		sshKeyPairField := sshKeyPairJSON[updatedName].(string)
+		sshKeyPairField := fmt.Sprintf("%v", sshKeyPairJSON[updatedName])
 		if !r.MatchString(sshKeyPairField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_ssh_keypair.go
+++ b/cloudstack/data_source_cloudstack_ssh_keypair.go
@@ -103,7 +103,11 @@ func applySshKeyPairsFilters(sshKeyPair *cloudstack.SSHKeyPair, filters *schema.
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		sshKeyPairField := fmt.Sprintf("%v", sshKeyPairJSON[updatedName])
+		sshKeyPairFieldValue, sshKeyPairFieldFound := sshKeyPairJSON[updatedName]
+		if !sshKeyPairFieldFound || sshKeyPairFieldValue == nil {
+			return false, nil
+		}
+		sshKeyPairField := fmt.Sprintf("%v", sshKeyPairFieldValue)
 		if !r.MatchString(sshKeyPairField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_template.go
+++ b/cloudstack/data_source_cloudstack_template.go
@@ -182,7 +182,7 @@ func applyFilters(template *cloudstack.Template, filters *schema.Set) (bool, err
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		templateField := templateJSON[updatedName].(string)
+		templateField := fmt.Sprintf("%v", templateJSON[updatedName])
 		if !r.MatchString(templateField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_template.go
+++ b/cloudstack/data_source_cloudstack_template.go
@@ -182,7 +182,11 @@ func applyFilters(template *cloudstack.Template, filters *schema.Set) (bool, err
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		templateField := fmt.Sprintf("%v", templateJSON[updatedName])
+		templateFieldValue, templateFieldFound := templateJSON[updatedName]
+		if !templateFieldFound || templateFieldValue == nil {
+			return false, nil
+		}
+		templateField := fmt.Sprintf("%v", templateFieldValue)
 		if !r.MatchString(templateField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_user.go
+++ b/cloudstack/data_source_cloudstack_user.go
@@ -145,7 +145,7 @@ func applyUserFilters(user *cloudstack.User, filters *schema.Set) (bool, error) 
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		userField := userJSON[updatedName].(string)
+		userField := fmt.Sprintf("%v", userJSON[updatedName])
 		if !r.MatchString(userField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_user.go
+++ b/cloudstack/data_source_cloudstack_user.go
@@ -145,7 +145,11 @@ func applyUserFilters(user *cloudstack.User, filters *schema.Set) (bool, error) 
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		userField := fmt.Sprintf("%v", userJSON[updatedName])
+		userFieldValue, userFieldFound := userJSON[updatedName]
+		if !userFieldFound || userFieldValue == nil {
+			return false, nil
+		}
+		userField := fmt.Sprintf("%v", userFieldValue)
 		if !r.MatchString(userField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_volume.go
+++ b/cloudstack/data_source_cloudstack_volume.go
@@ -133,7 +133,7 @@ func applyVolumeFilters(volume *cloudstack.Volume, filters *schema.Set) (bool, e
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		volume := volumeJSON[updatedName].(string)
+		volume := fmt.Sprintf("%v", volumeJSON[updatedName])
 		if !r.MatchString(volume) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_volume.go
+++ b/cloudstack/data_source_cloudstack_volume.go
@@ -133,7 +133,11 @@ func applyVolumeFilters(volume *cloudstack.Volume, filters *schema.Set) (bool, e
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		volume := fmt.Sprintf("%v", volumeJSON[updatedName])
+		volumeValue, volumeFound := volumeJSON[updatedName]
+		if !volumeFound || volumeValue == nil {
+			return false, nil
+		}
+		volume := fmt.Sprintf("%v", volumeValue)
 		if !r.MatchString(volume) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_vpc.go
+++ b/cloudstack/data_source_cloudstack_vpc.go
@@ -171,7 +171,7 @@ func applyVPCFilters(vpc *cloudstack.VPC, filters *schema.Set) (bool, error) {
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		vpcField := vpcJSON[updatedName].(string)
+		vpcField := fmt.Sprintf("%v", vpcJSON[updatedName])
 		if !r.MatchString(vpcField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_vpc.go
+++ b/cloudstack/data_source_cloudstack_vpc.go
@@ -171,7 +171,11 @@ func applyVPCFilters(vpc *cloudstack.VPC, filters *schema.Set) (bool, error) {
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		vpcField := fmt.Sprintf("%v", vpcJSON[updatedName])
+		vpcFieldValue, vpcFieldFound := vpcJSON[updatedName]
+		if !vpcFieldFound || vpcFieldValue == nil {
+			return false, nil
+		}
+		vpcField := fmt.Sprintf("%v", vpcFieldValue)
 		if !r.MatchString(vpcField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_vpc_offering.go
+++ b/cloudstack/data_source_cloudstack_vpc_offering.go
@@ -220,7 +220,11 @@ func applyVPCOfferingFilters(vpcOffering *cloudstack.VPCOffering, filters *schem
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		vpcOfferingField := fmt.Sprintf("%v", vpcOfferingJSON[updatedName])
+		vpcOfferingFieldValue, vpcOfferingFieldFound := vpcOfferingJSON[updatedName]
+		if !vpcOfferingFieldFound || vpcOfferingFieldValue == nil {
+			return false, nil
+		}
+		vpcOfferingField := fmt.Sprintf("%v", vpcOfferingFieldValue)
 		if !r.MatchString(vpcOfferingField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_vpn_connection.go
+++ b/cloudstack/data_source_cloudstack_vpn_connection.go
@@ -131,7 +131,7 @@ func applyVPNConnectionFilters(vpnConnection *cloudstack.VpnConnection, filters 
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		vpnConnectionField := vpnConnectionJSON[updatedName].(string)
+		vpnConnectionField := fmt.Sprintf("%v", vpnConnectionJSON[updatedName])
 		if !r.MatchString(vpnConnectionField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_vpn_connection.go
+++ b/cloudstack/data_source_cloudstack_vpn_connection.go
@@ -131,7 +131,11 @@ func applyVPNConnectionFilters(vpnConnection *cloudstack.VpnConnection, filters 
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
 		log.Print(updatedName)
-		vpnConnectionField := fmt.Sprintf("%v", vpnConnectionJSON[updatedName])
+		vpnConnectionFieldValue, vpnConnectionFieldFound := vpnConnectionJSON[updatedName]
+		if !vpnConnectionFieldFound || vpnConnectionFieldValue == nil {
+			return false, nil
+		}
+		vpnConnectionField := fmt.Sprintf("%v", vpnConnectionFieldValue)
 		if !r.MatchString(vpnConnectionField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_zone.go
+++ b/cloudstack/data_source_cloudstack_zone.go
@@ -111,7 +111,7 @@ func applyZoneFilters(zone *cloudstack.Zone, filters *schema.Set) (bool, error) 
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		zoneField := zoneJSON[updatedName].(string)
+		zoneField := fmt.Sprintf("%v", zoneJSON[updatedName])
 		if !r.MatchString(zoneField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_cloudstack_zone.go
+++ b/cloudstack/data_source_cloudstack_zone.go
@@ -111,7 +111,11 @@ func applyZoneFilters(zone *cloudstack.Zone, filters *schema.Set) (bool, error) 
 			return false, fmt.Errorf("Invalid regex: %s", err)
 		}
 		updatedName := strings.ReplaceAll(m["name"].(string), "_", "")
-		zoneField := fmt.Sprintf("%v", zoneJSON[updatedName])
+		zoneFieldValue, zoneFieldFound := zoneJSON[updatedName]
+		if !zoneFieldFound || zoneFieldValue == nil {
+			return false, nil
+		}
+		zoneField := fmt.Sprintf("%v", zoneFieldValue)
 		if !r.MatchString(zoneField) {
 			return false, nil
 		}

--- a/cloudstack/data_source_filter_panic_unit_test.go
+++ b/cloudstack/data_source_filter_panic_unit_test.go
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cloudstack
+
+import (
+	"testing"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dsPanicFilterSet(pairs ...[2]string) *schema.Set {
+	hash := func(i interface{}) int {
+		m := i.(map[string]interface{})
+		return schema.HashString(m["name"].(string) + "|" + m["value"].(string))
+	}
+	items := make([]interface{}, 0, len(pairs))
+	for _, p := range pairs {
+		items = append(items, map[string]interface{}{"name": p[0], "value": p[1]})
+	}
+	return schema.NewSet(hash, items)
+}
+
+// A data-source filter referencing an unknown field name, or a non-string field, must not panic.
+func TestApplyVolumeFiltersDoesNotPanicOnUnknownOrNonStringField(t *testing.T) {
+	vol := &cloudstack.Volume{Name: "vol-a", Size: 5368709120}
+
+	// Unknown filter field: the JSON lookup returns nil; must not panic and must not match.
+	if match, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"no_such_field", "x"})); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if match {
+		t.Errorf("an unknown filter field should not match")
+	}
+
+	// Non-string (numeric) field: the JSON value is a float64; must not panic.
+	if _, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"size", "anything"})); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}

--- a/cloudstack/data_source_filter_panic_unit_test.go
+++ b/cloudstack/data_source_filter_panic_unit_test.go
@@ -38,7 +38,7 @@ func dsPanicFilterSet(pairs ...[2]string) *schema.Set {
 
 // A data-source filter referencing an unknown field name, or a non-string field, must not panic.
 func TestApplyVolumeFiltersDoesNotPanicOnUnknownOrNonStringField(t *testing.T) {
-	vol := &cloudstack.Volume{Name: "vol-a", Size: 5368709120}
+	vol := &cloudstack.Volume{Name: "vol-a", Size: 5}
 
 	// Unknown filter field: the JSON lookup returns nil; must not panic and must not match.
 	if match, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"no_such_field", "x"})); err != nil {
@@ -47,8 +47,24 @@ func TestApplyVolumeFiltersDoesNotPanicOnUnknownOrNonStringField(t *testing.T) {
 		t.Errorf("an unknown filter field should not match")
 	}
 
-	// Non-string (numeric) field: the JSON value is a float64; must not panic.
-	if _, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"size", "anything"})); err != nil {
+	// A permissive regex must not match a field that does not exist.
+	if match, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"no_such_field", ".*"})); err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	} else if match {
+		t.Errorf("a nonexistent field should not match even a permissive regex")
+	}
+
+	// A numeric field is stringified and matched against the regex.
+	if match, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"size", "^5$"})); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !match {
+		t.Errorf("a numeric field should match its string representation")
+	}
+
+	// An existing field must still match.
+	if match, err := applyVolumeFilters(vol, dsPanicFilterSet([2]string{"name", "vol-a"})); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !match {
+		t.Errorf("an existing field that matches the regex should match")
 	}
 }


### PR DESCRIPTION
### Description

Several data sources match their filters against the looked-up JSON field, and there were two problems with the JSON-backed implementations.

They asserted the value as a string, for example `volumeJSON[name].(string)`. A filter on a field that does not exist gets `nil`, and one on a numeric field gets a `float64`, so the assertion panics the provider with `interface conversion: interface {} is nil, not string`.

Stringifying with `fmt.Sprintf("%v", ...)` alone is still wrong for a missing field, since `fmt.Sprintf("%v", nil)` is the literal `<nil>`, which a permissive regex such as `.*` would match, so a filter on a nonexistent field could match.

Fixed both across the affected JSON-backed data source filters: look the field up explicitly, return no match when it is absent or nil, and otherwise stringify with `fmt.Sprintf("%v", ...)` so numeric and bool fields match safely. The reflection based (pod, cluster) and custom (role, project) filter implementations work differently and are not touched here.

### Testing

Added a unit test on the volume data source covering a filter on an unknown field, a permissive regex on a missing field, a numeric field matched against its string form, and a positive match. It needs no live CloudStack:

    go test ./cloudstack/ -run TestApplyVolumeFiltersDoesNotPanicOnUnknownOrNonStringField

The unknown and numeric cases panic against the original code, and the missing-field case matches `<nil>`; all pass with the fix.
